### PR TITLE
Add Jenkins pipeline and documentation

### DIFF
--- a/deploy-script.sh
+++ b/deploy-script.sh
@@ -1,11 +1,40 @@
 #!/bin/bash
 set -euo pipefail
 
-# Example deployment script
-# Expect environment variables for remote host and user
+# Usage: deploy-script.sh <docker_registry> <remote_ip>
+DOCKER_REGISTRY=${1:-""}
+REMOTE_HOST=${2:-"localhost"}
 
-ssh "$remote_user@$remote_host" <<'REMOTE'
-  cd /opt/zammad
-  docker-compose pull
-  docker-compose up -d
-REMOTE
+echo "🚀 Deploying Zammad stack (registry: $DOCKER_REGISTRY, host: $REMOTE_HOST)"
+
+# Install Docker if not present
+if ! command -v docker &>/dev/null; then
+    echo "📦 Installing Docker..."
+    curl -fsSL https://get.docker.com -o get-docker.sh
+    sudo sh get-docker.sh
+    sudo systemctl enable --now docker
+fi
+
+# Install Docker Compose if not present
+if ! command -v docker-compose &>/dev/null; then
+    echo "📦 Installing Docker Compose..."
+    sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    sudo chmod +x /usr/local/bin/docker-compose
+fi
+
+# Create data directories
+sudo mkdir -p data/postgres data/elasticsearch data/zammad certs certs-data nginx/conf.d
+sudo chown -R "$USER:$USER" data certs certs-data nginx
+
+# Replace registry placeholder if present
+if grep -q "\${DOCKER_REGISTRY}" docker-compose.yaml 2>/dev/null; then
+    sed -i "s|\${DOCKER_REGISTRY}|$DOCKER_REGISTRY|g" docker-compose.yaml
+fi
+
+# Pull and run containers
+docker-compose pull
+docker-compose up -d
+
+docker-compose ps
+
+echo "✅ Deployment complete"


### PR DESCRIPTION
## Summary
- add full Jenkins pipeline to build, push and deploy over SSH
- update deploy script for remote use
- expand CI/CD guide with setup, webhook configuration, credential details and troubleshooting
- clarify docs to explain optional image build step

## Testing
- `apt-get update`
- `apt-get install -y shellcheck`
- `shellcheck deploy-script.sh`
- `bash -n deploy-script.sh`


------
https://chatgpt.com/codex/tasks/task_e_6862e86c5b38832c90a9b2b998681a9d