### PR TITLE
Add dockerized service definitions

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,56 +1,79 @@
 version: '3.9'
 
+networks:
+  zammad-net:
+
+volumes:
+  zammad_data:
+  postgres_data:
+  elastic_data:
+  certbot_conf:
+  certbot_www:
+
 services:
-  postgres:
-    image: postgres:15-alpine
+  postgresql:
+    build: ./services/postgresql
+    image: ${DOCKER_REGISTRY}/postgresql:latest
     restart: always
     environment:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
-      - ./data/postgres:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - zammad-net
 
   elasticsearch:
-    image: elasticsearch:7.17.12
+    build: ./services/elasticsearch
+    image: ${DOCKER_REGISTRY}/elasticsearch:latest
     restart: always
     environment:
       discovery.type: single-node
       ES_JAVA_OPTS: ${ES_JAVA_OPTS}
     volumes:
-      - ./data/elasticsearch:/usr/share/elasticsearch/data
+      - elastic_data:/usr/share/elasticsearch/data
+    networks:
+      - zammad-net
 
   zammad:
-    image: zammad/zammad:latest
+    build: ./services/zammad
+    image: ${DOCKER_REGISTRY}/zammad:latest
     restart: always
     depends_on:
-      - postgres
+      - postgresql
       - elasticsearch
     environment:
-      - POSTGRESQL_HOST=postgres
-      - ELASTICSEARCH_HOST=elasticsearch
-      - ZAMMAD_RAILS_TRUSTED_PROXIES=0.0.0.0/0
+      POSTGRESQL_HOST: postgresql
+      ELASTICSEARCH_HOST: elasticsearch
+      ZAMMAD_RAILS_TRUSTED_PROXIES: 0.0.0.0/0
     env_file:
       - .env
     volumes:
-      - ./data/zammad:/opt/zammad
+      - zammad_data:/opt/zammad
+    networks:
+      - zammad-net
 
   nginx:
-    image: nginx:alpine
+    build: ./services/nginx
+    image: ${DOCKER_REGISTRY}/nginx:latest
     depends_on:
       - zammad
     volumes:
-      - ./nginx/conf.d:/etc/nginx/conf.d
-      - ./certs:/etc/letsencrypt
-      - ./certs-data:/var/lib/letsencrypt
+      - certbot_conf:/etc/letsencrypt
+      - certbot_www:/var/www/certbot
     ports:
       - "80:80"
       - "443:443"
+    networks:
+      - zammad-net
 
   certbot:
-    image: certbot/certbot
+    build: ./services/certbot
+    image: ${DOCKER_REGISTRY}/certbot:latest
     volumes:
-      - ./certs:/etc/letsencrypt
-      - ./certs-data:/var/lib/letsencrypt
-      - ./nginx/conf.d:/etc/nginx/conf.d
+      - certbot_conf:/etc/letsencrypt
+      - certbot_www:/var/www/certbot
     entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
+    networks:
+      - zammad-net

--- a/docs/nginx-certbot.md
+++ b/docs/nginx-certbot.md
@@ -1,0 +1,12 @@
+# NGINX and Certbot
+
+This document explains how the reverse proxy container works together with Certbot to provide HTTPS certificates.
+
+NGINX serves as a reverse proxy in front of the Zammad application. The configuration in `services/nginx/conf.d/zammad.conf` forwards traffic to the `zammad` container and exposes the `/.well-known/acme-challenge/` path for Let's Encrypt validation.
+
+The `certbot` container shares two volumes with NGINX:
+
+- `certbot_conf` - stores issued certificates under `/etc/letsencrypt`
+- `certbot_www` - served by NGINX under `/var/www/certbot` for HTTP-01 challenges
+
+During renewal the certbot container runs a loop which calls `certbot renew` every 12 hours. NGINX uses the same certificate files from `certbot_conf` so renewed certificates are picked up automatically after reload.

--- a/services/certbot/Dockerfile
+++ b/services/certbot/Dockerfile
@@ -1,0 +1,6 @@
+# Certbot Dockerfile
+FROM certbot/certbot
+
+VOLUME ["/etc/letsencrypt", "/var/www/certbot"]
+
+CMD ["certbot"]

--- a/services/elasticsearch/Dockerfile
+++ b/services/elasticsearch/Dockerfile
@@ -1,0 +1,9 @@
+# Elasticsearch service Dockerfile
+FROM elasticsearch:7.17.12
+
+ENV discovery.type=single-node \
+    ES_JAVA_OPTS="-Xms512m -Xmx512m"
+
+VOLUME ["/usr/share/elasticsearch/data"]
+
+CMD ["/usr/local/bin/docker-entrypoint.sh"]

--- a/services/nginx/Dockerfile
+++ b/services/nginx/Dockerfile
@@ -1,0 +1,8 @@
+# Nginx reverse proxy Dockerfile
+FROM nginx:alpine
+
+COPY conf.d /etc/nginx/conf.d
+
+VOLUME ["/var/www/certbot", "/etc/letsencrypt"]
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/services/nginx/conf.d/zammad.conf
+++ b/services/nginx/conf.d/zammad.conf
@@ -1,0 +1,14 @@
+server {
+    listen 80;
+    server_name _;
+
+    location / {
+        proxy_pass http://zammad:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location ~ /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+}

--- a/services/postgresql/Dockerfile
+++ b/services/postgresql/Dockerfile
@@ -1,0 +1,11 @@
+# PostgreSQL service Dockerfile
+FROM postgres:15-alpine
+
+# Set default environment variables
+ENV POSTGRES_DB=zammad \
+    POSTGRES_USER=zammad \
+    POSTGRES_PASSWORD=zammad
+
+VOLUME ["/var/lib/postgresql/data"]
+
+CMD ["docker-entrypoint.sh", "postgres"]

--- a/services/zammad/Dockerfile
+++ b/services/zammad/Dockerfile
@@ -1,0 +1,9 @@
+# Zammad service Dockerfile
+FROM zammad/zammad:latest
+
+# Expose default ports
+EXPOSE 3000 6042
+
+VOLUME ["/opt/zammad"]
+
+CMD ["/docker-entrypoint.sh"]


### PR DESCRIPTION
## Summary
- build service-specific images for postgresql, elasticsearch, zammad, nginx and certbot
- add Docker compose stack using named volumes and a shared network
- document per-service deployment details and nginx+certbot integration

## Testing
- `docker-compose --version`
- `docker-compose config`

------
https://chatgpt.com/codex/tasks/task_e_6862f0fb6208832ca38cd51cc2930972