### PR TITLE
Inject REMOTE_DOMAIN credential into deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Domain and Admin Email
-DOMAIN=example.com
+DOMAIN=${REMOTE_DOMAIN}
 ADMIN_EMAIL=admin@example.com
 
 # Microsoft 365 OAuth2 Credentials

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,14 +70,15 @@ pipeline {
                         sshUserPrivateKey(credentialsId: 'ssh-remote-server-hostinger-deploy', keyFileVariable: 'SSH_KEY'),
                         string(credentialsId: 'remote-user', variable: 'REMOTE_USER'),
                         string(credentialsId: 'remote-hostinger-deploy-ip', variable: 'REMOTE_HOST'),
-                        string(credentialsId: 'docker-registry', variable: 'DOCKER_REGISTRY')
+                        string(credentialsId: 'docker-registry', variable: 'DOCKER_REGISTRY'),
+                        string(credentialsId: 'remote-hostinger-domain', variable: 'REMOTE_DOMAIN')
                     ]) {
                         sh '''
                             ssh -i "$SSH_KEY" -o StrictHostKeyChecking=no "$REMOTE_USER@$REMOTE_HOST" "sudo mkdir -p /opt/zammad && sudo chown $REMOTE_USER:$REMOTE_USER /opt/zammad"
                             scp -i "$SSH_KEY" -o StrictHostKeyChecking=no docker-compose.yaml "$REMOTE_USER@$REMOTE_HOST:/opt/zammad/"
                             scp -i "$SSH_KEY" -o StrictHostKeyChecking=no deploy-script.sh "$REMOTE_USER@$REMOTE_HOST:/opt/zammad/"
                             scp -i "$SSH_KEY" -o StrictHostKeyChecking=no .env.example "$REMOTE_USER@$REMOTE_HOST:/opt/zammad/.env"
-                            ssh -i "$SSH_KEY" -o StrictHostKeyChecking=no "$REMOTE_USER@$REMOTE_HOST" "cd /opt/zammad && chmod +x deploy-script.sh && ./deploy-script.sh '$DOCKER_REGISTRY' '$REMOTE_HOST'"
+                            ssh -i "$SSH_KEY" -o StrictHostKeyChecking=no "$REMOTE_USER@$REMOTE_HOST" "cd /opt/zammad && chmod +x deploy-script.sh && ./deploy-script.sh '$DOCKER_REGISTRY' '$REMOTE_HOST' '$REMOTE_DOMAIN'"
                         '''
                     }
                 }

--- a/deploy-script.sh
+++ b/deploy-script.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
-# Usage: deploy-script.sh <docker_registry> <remote_ip>
+# Usage: deploy-script.sh <docker_registry> <remote_ip> <remote_domain>
 DOCKER_REGISTRY=${1:-""}
 REMOTE_HOST=${2:-"localhost"}
+REMOTE_DOMAIN=${3:-"localhost"}
 
-echo "🚀 Deploying Zammad stack (registry: $DOCKER_REGISTRY, host: $REMOTE_HOST)"
+echo "🚀 Deploying Zammad stack (registry: $DOCKER_REGISTRY, host: $REMOTE_HOST, domain: $REMOTE_DOMAIN)"
 
 # Install Docker if not present
 if ! command -v docker &>/dev/null; then
@@ -29,6 +30,15 @@ sudo chown -R "$USER:$USER" data certs certs-data nginx
 # Replace registry placeholder if present
 if grep -q "\${DOCKER_REGISTRY}" docker-compose.yaml 2>/dev/null; then
     sed -i "s|\${DOCKER_REGISTRY}|$DOCKER_REGISTRY|g" docker-compose.yaml
+fi
+
+# Replace domain placeholder if present
+if grep -q "\${REMOTE_DOMAIN}" docker-compose.yaml 2>/dev/null; then
+    sed -i "s|\${REMOTE_DOMAIN}|$REMOTE_DOMAIN|g" docker-compose.yaml
+fi
+
+if grep -q "\${REMOTE_DOMAIN}" .env 2>/dev/null; then
+    sed -i "s|\${REMOTE_DOMAIN}|$REMOTE_DOMAIN|g" .env
 fi
 
 # Pull and run containers

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,6 +47,7 @@ services:
       POSTGRESQL_HOST: postgresql
       ELASTICSEARCH_HOST: elasticsearch
       ZAMMAD_RAILS_TRUSTED_PROXIES: 0.0.0.0/0
+      ZAMMAD_FQDN: ${REMOTE_DOMAIN}
     env_file:
       - .env
     volumes:

--- a/docs/ci-cd-pipeline.md
+++ b/docs/ci-cd-pipeline.md
@@ -36,6 +36,7 @@ The following Jenkins credentials are referenced in the pipeline and should be c
 | `docker-registry`                       | Docker Hub namespace/registry          |
 | `ssh-remote-server-hostinger-deploy`    | Private key for remote VPS             |
 | `remote-hostinger-deploy-ip`            | IP address of the Hostinger server     |
+| `remote-hostinger-domain`               | Domain name used for production deployment of Zammad |
 | `remote-user`                           | Remote Linux user (usually `root`)     |
 
 ## 4. Jenkinsfile Stages

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -35,8 +35,11 @@ These volumes are defined in `docker-compose.yaml` and ensure data is retained a
 ## Running the stack
 
 1. Copy `.env.example` to `.env` and adjust values to suit your environment.
+   The `DOMAIN` entry will be replaced automatically during the Jenkins deployment
+   using the `remote-hostinger-domain` credential.
 2. Build and start the containers:
    ```bash
    docker-compose up -d
    ```
 3. The application will be available via the domain configured in your DNS pointing to the server.
+   This value is injected as `ZAMMAD_FQDN` and referenced by the NGINX configuration for TLS generation.


### PR DESCRIPTION
## Summary
- use `${REMOTE_DOMAIN}` placeholder in `.env.example` and compose
- replace domain placeholder via updated `deploy-script.sh`
- pass domain credential in Jenkinsfile deployment step
- document new Jenkins credential and domain injection process

## Testing
- `bash -n deploy-script.sh`

------
https://chatgpt.com/codex/tasks/task_e_6862f26f72ec832c8141f5261568ff77