### PR TITLE
Add basic homepage and proxy to Zammad

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -61,6 +61,7 @@ services:
     depends_on:
       - zammad
     volumes:
+      - ./services/nginx/html:/usr/share/nginx/html
       - certbot_conf:/etc/letsencrypt
       - certbot_www:/var/www/certbot
     ports:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -43,3 +43,4 @@ These volumes are defined in `docker-compose.yaml` and ensure data is retained a
    ```
 3. The application will be available via the domain configured in your DNS pointing to the server.
    This value is injected as `ZAMMAD_FQDN` and referenced by the NGINX configuration for TLS generation.
+4. Visiting the root of your domain displays a simple welcome page with a link to `/zammad`.

--- a/docs/nginx-certbot.md
+++ b/docs/nginx-certbot.md
@@ -3,6 +3,7 @@
 This document explains how the reverse proxy container works together with Certbot to provide HTTPS certificates.
 
 NGINX serves as a reverse proxy in front of the Zammad application. The configuration in `services/nginx/conf.d/zammad.conf` forwards traffic to the `zammad` container and exposes the `/.well-known/acme-challenge/` path for Let's Encrypt validation.
+The root of the domain serves a static `index.html` page and any requests under `/zammad` are proxied to the Zammad container.
 
 The `certbot` container shares two volumes with NGINX:
 

--- a/services/nginx/Dockerfile
+++ b/services/nginx/Dockerfile
@@ -2,6 +2,7 @@
 FROM nginx:alpine
 
 COPY conf.d /etc/nginx/conf.d
+COPY html /usr/share/nginx/html
 
 VOLUME ["/var/www/certbot", "/etc/letsencrypt"]
 

--- a/services/nginx/conf.d/zammad.conf
+++ b/services/nginx/conf.d/zammad.conf
@@ -1,11 +1,18 @@
 server {
     listen 80;
-    server_name _;
+    server_name ${REMOTE_DOMAIN};
 
     location / {
-        proxy_pass http://zammad:3000;
+        root /usr/share/nginx/html;
+        index index.html;
+    }
+
+    location /zammad/ {
+        proxy_pass http://zammad:3000/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     location ~ /.well-known/acme-challenge/ {

--- a/services/nginx/html/index.html
+++ b/services/nginx/html/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Zammad Hostinger Project</title>
+  <style>
+    body { font-family: sans-serif; text-align: center; padding: 50px; }
+    a { font-size: 20px; color: #007bff; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <h1>Welcome to the Zammad Ticketing Hostinger Project</h1>
+  <p>This is a temporary homepage for testing purposes.</p>
+  <p><a href="/zammad">Go to Zammad &rarr;</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- serve a simple index.html page from nginx
- copy static html assets in nginx image
- reverse proxy `/zammad` to the application
- mount html directory in docker-compose
- document the new behavior in deployment and nginx docs

## Testing
- `docker-compose -f docker-compose.yaml config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f78c4594832cbeab31e9a259335e