### PR TITLE
Add credential management policy docs

### DIFF
--- a/agent_prompt.md
+++ b/agent_prompt.md
@@ -124,6 +124,19 @@ For each new component (Zammad, NGINX, Certbot, etc.), the following must be del
 
 ---
 
+## 🔐 Credential Management Policy
+
+1. **All Paid Services Must Use Jenkins Secrets** – any credential for paid or sensitive services (Microsoft 365, DockerHub, domain certificates, remote SSH) is injected at runtime using Jenkins credential bindings. These values must never be committed to the repository.
+2. **Secret Centralization** – Jenkins is the only approved location for storing OAuth credentials, DockerHub logins, Certbot email, SSH keys, and domain/IP details. Do not store these in `.env` files or echo them in logs. Reference them by credential ID in the `Jenkinsfile`.
+3. **Documentation Format** – every guide should include the block below to remind contributors that secrets are managed by Jenkins:
+
+```
+> **⚠️ Sensitive Keys**  
+> All required keys and secrets for this integration are injected securely via Jenkins and are not stored in this repository.
+```
+
+---
+
 ## 🚧 Work Strategy
 
 Each step/task (service, feature, integration) is handled as a discrete documented unit.

--- a/docs/agent_prompt.md
+++ b/docs/agent_prompt.md
@@ -124,6 +124,19 @@ For each new component (Zammad, NGINX, Certbot, etc.), the following must be del
 
 ---
 
+## 🔐 Credential Management Policy
+
+1. **All Paid Services Must Use Jenkins Secrets** – any credential for paid or sensitive services (Microsoft 365, DockerHub, domain certificates, remote SSH) is injected at runtime using Jenkins credential bindings. These values must never be committed to the repository.
+2. **Secret Centralization** – Jenkins is the only approved location for storing OAuth credentials, DockerHub logins, Certbot email, SSH keys, and domain/IP details. Do not store these in `.env` files or echo them in logs. Reference them by credential ID in the `Jenkinsfile`.
+3. **Documentation Format** – every guide should include the block below to remind contributors that secrets are managed by Jenkins:
+
+```
+> **⚠️ Sensitive Keys**  
+> All required keys and secrets for this integration are injected securely via Jenkins and are not stored in this repository.
+```
+
+---
+
 ## 🚧 Work Strategy
 
 Each step/task (service, feature, integration) is handled as a discrete documented unit.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,8 @@
+# Authentication and SSO
+
+Zammad can integrate with Microsoft 365 / Entra ID for single sign-on.
+
+> **⚠️ Sensitive Keys**  
+> All required keys and secrets for this integration are injected securely via Jenkins and are not stored in this repository.
+
+When implemented, configure the necessary OAuth application in Microsoft 365 and store the credentials in Jenkins. Reference these credential IDs from the pipeline to pass them into the container.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,6 +2,27 @@
 
 This guide explains how each service in the stack is containerised and where its data is stored. All containers connect to the `zammad-net` Docker network so they can communicate internally.
 
+## 🔐 Credential Management Policy
+
+All credentials for paid services or sensitive infrastructure are stored as Jenkins secrets and injected at runtime. This includes Microsoft 365 OAuth details, DockerHub logins, Certbot email, SSH keys, and your domain/IP settings. Never commit these values to `.env` files or echo them in logs—reference the credential IDs from the `Jenkinsfile`.
+
+| Jenkins ID                              | Purpose |
+|-----------------------------------------|---------|
+| `github-credentials`                    | SSH key used to pull the repository |
+| `dockerhub-credentials`                 | DockerHub login for pushing images |
+| `docker-registry`                       | Docker Hub namespace/registry |
+| `ssh-remote-server-hostinger-deploy`    | Private key for remote VPS |
+| `remote-hostinger-deploy-ip`            | IP address of the Hostinger server |
+| `remote-user`                           | Remote Linux user |
+| `remote-hostinger-domain`               | Domain name used for deployment |
+| `certbot-email`                         | Email for Let's Encrypt registration |
+| `m365-tenant-id`                        | Microsoft 365 tenant ID |
+| `m365-client-id`                        | Microsoft 365 application ID |
+| `m365-client-secret`                    | Microsoft 365 application secret |
+| `m365-smtp-user`                        | SMTP user account |
+| `m365-smtp-password`                    | SMTP password/token |
+| `m365-shared-mailbox`                   | Shared mailbox address |
+
 ## Services
 
 ### postgres

--- a/docs/email-integration.md
+++ b/docs/email-integration.md
@@ -1,0 +1,17 @@
+# Email Integration
+
+This guide explains how Zammad sends and receives email using Microsoft 365.
+
+> **⚠️ Sensitive Keys**  
+> All required keys and secrets for this integration are injected securely via Jenkins and are not stored in this repository.
+
+Microsoft 365 OAuth2 credentials and SMTP settings are provided via the following Jenkins secrets:
+
+- `m365-tenant-id`
+- `m365-client-id`
+- `m365-client-secret`
+- `m365-smtp-user`
+- `m365-smtp-password`
+- `m365-shared-mailbox`
+
+Configure these secrets in Jenkins and reference them in the pipeline so the Zammad container can authenticate with Microsoft 365.

--- a/docs/nginx-certbot.md
+++ b/docs/nginx-certbot.md
@@ -2,6 +2,9 @@
 
 This guide describes how the project uses [Certbot](https://certbot.eff.org/) together with NGINX to obtain and renew free TLS certificates from Let's Encrypt.
 
+> **⚠️ Sensitive Keys**  
+> All required keys and secrets for this integration are injected securely via Jenkins and are not stored in this repository.
+
 ## Overview
 
 Certbot automates the process of requesting and renewing certificates. We run it in a Docker container so it can share volumes with our NGINX reverse proxy. The container image is built from [`services/certbot/Dockerfile`](../services/certbot/Dockerfile), which extends the official `certbot/certbot` image. The **webroot** challenge method is used because it only requires serving files from a known directory, making it simple and reliable in a containerized environment.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,20 @@
+# Jenkins Secrets Index
+
+The following credential IDs are referenced by the deployment pipeline. Values are stored only in Jenkins and never in this repository.
+
+| Jenkins ID                              | Purpose |
+|-----------------------------------------|---------|
+| `github-credentials`                    | SSH key used to pull the repository |
+| `dockerhub-credentials`                 | DockerHub login for pushing images |
+| `docker-registry`                       | Docker Hub namespace/registry |
+| `ssh-remote-server-hostinger-deploy`    | Private key for remote VPS |
+| `remote-hostinger-deploy-ip`            | IP address of the Hostinger server |
+| `remote-user`                           | Remote Linux user |
+| `remote-hostinger-domain`               | Domain name used for deployment |
+| `certbot-email`                         | Email for Let's Encrypt registration |
+| `m365-tenant-id`                        | Microsoft 365 tenant ID |
+| `m365-client-id`                        | Microsoft 365 application ID |
+| `m365-client-secret`                    | Microsoft 365 application secret |
+| `m365-smtp-user`                        | SMTP user account |
+| `m365-smtp-password`                    | SMTP password/token |
+| `m365-shared-mailbox`                   | Shared mailbox address |


### PR DESCRIPTION
## Summary
- document secrets policy in agent_prompt
- clarify credential policy in project documentation
- add warning blocks to certbot guide and new integration docs
- list Jenkins secrets in a dedicated file

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68631a438c18832cbca136bce7396f4e