### PR TITLE
Improve documentation structure and linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Welcome! 👋
 - [Project Vision](#-project-vision)
 - [Goals](#-goals)
 - [Technology Stack](#-technology-stack)
+- [Quick Start](#-quick-start)
 - [Learning Together](#-learning-together)
 - [Next Steps & Contribution](#-next-steps--contribution)
 - [Documentation](#-documentation)
@@ -43,6 +44,20 @@ In the longer term, I'm enthusiastic about exploring integrations with **AI agen
 * **Structured Document Handling (Future integration):** Systematic processing and management of uploaded documents.
 * **AI Agents & MCP (Future integration):** Intelligent, dynamic workflow automation and customer interaction enhancements.
 
+## 🚀 Quick Start
+
+1. Clone this repository and enter the directory:
+   ```bash
+   git clone https://github.com/NoSayMe/zammad-ticketing-hostinger.git
+   cd zammad-ticketing-hostinger
+   ```
+2. Copy `.env.example` to `.env` and adjust the values for your environment.
+3. Start the stack locally:
+   ```bash
+   docker-compose up -d
+   ```
+4. Visit `http://localhost` to see the landing page. For production deployment follow the [Deployment guide](docs/deployment.md).
+
 ## 📚 Learning Together
 
 This project is not just about creating software—it's about learning, growing, and contributing together. I'm actively collaborating with freelance developers initially to set a solid foundation, guide structure, and ensure best practices.
@@ -56,15 +71,20 @@ Whether you're a seasoned developer, an enthusiastic learner, or simply passiona
 * Develop robust documentation for ease of use.
 * Enhance and test Microsoft 365 integration features.
 
-Feel free to open issues, suggest features, submit pull requests, or simply share your ideas!
+Contributions are welcome! Fork the repository, create a feature branch and open a pull request when you're ready. You can also open issues to discuss ideas or problems.
 
 ## 📖 Documentation
 
 All additional guides are stored in the [`docs/`](docs/) directory:
 
-- **[deployment.md](docs/deployment.md)** – step-by-step instructions to run the Zammad stack with Docker Compose.
-- **[ci-cd-pipeline.md](docs/ci-cd-pipeline.md)** – explains the Jenkins pipeline used for automated deployments.
-- **[nginx-certbot.md](docs/nginx-certbot.md)** – details the HTTPS setup using Certbot and NGINX.
+- **[deployment.md](docs/deployment.md)** – step-by-step Docker setup and environments.
+- **[ci-cd-pipeline.md](docs/ci-cd-pipeline.md)** – Jenkins and automation logic.
+- **[authentication.md](docs/authentication.md)** – LDAP, Entra ID, Microsoft login setup.
+- **[email-integration.md](docs/email-integration.md)** – Outlook, shared mailbox config.
+- **[branding.md](docs/branding.md)** – Customization and UI theming.
+- **[certbot.md](docs/certbot.md)** – HTTPS setup with Certbot.
+- **[secrets.md](docs/secrets.md)** – Overview of Jenkins credential IDs.
+- **[troubleshooting.md](docs/troubleshooting.md)** – Accessing logs, common errors.
 
 These documents will grow alongside the project as more features (like Microsoft 365 integration or n8n workflows) are added.
 

--- a/agent_prompt.md
+++ b/agent_prompt.md
@@ -73,6 +73,19 @@ For every deployed or integrated component, you must:
 - Use real examples, and plain English
 - Prefer visual verification (e.g., accessible URL) and CLI checks (`docker ps`, `docker logs`, etc.)
 
+## 📚 Documentation Standards
+
+- `README.md` acts as the hub and must link to every guide in `docs/`.
+- Every markdown file under `docs/` starts with a backlink to `README.md` and ends with a navigation footer:
+
+  ```markdown
+  ---
+  🔗 Back to [Main README](../README.md)  
+  📚 See also: [Deployment](deployment.md) | [CI/CD](ci-cd-pipeline.md) | [Secrets](secrets.md)
+  ```
+- Use relative links when referencing other docs.
+- Keep headers and terminology consistent (e.g., "remote VPS").
+
 ---
 
 ## 🌐 (Optional) Containerized Wiki

--- a/docs/agent_prompt.md
+++ b/docs/agent_prompt.md
@@ -1,7 +1,8 @@
+[← Back to Main README](../README.md)
+
 You are contributing to an open-source project designed to create a secure, modular, and easy-to-deploy ticketing and automation platform based on Zammad and Docker. This project is being actively built to serve small to mid-sized organizations and educational purposes.
 
-⚠️ Above all, this project is **documentation-first**.  
-Every feature or service must be accompanied by clear, human-readable documentation that explains:
+⚠️ Above all, this project is **documentation-first**. Every feature or service must be accompanied by clear, human-readable documentation that explains:
 - What it does
 - How to install/deploy it
 - How to verify it works
@@ -32,23 +33,22 @@ This includes Markdown-based files in `/docs`, and optionally a `/wiki` containe
 
 You are responsible for creating, containerizing, and documenting the following:
 
-| Component        | Description                                                   |
-|------------------|---------------------------------------------------------------|
-| `zammad`         | Main ticketing system                                         |
-| `postgresql`     | Relational database backend for Zammad                        |
-| `elasticsearch`  | Search indexing backend                                       |
-| `nginx`          | TLS termination and reverse proxy                             |
-| `certbot`        | HTTPS certificate issuance and renewal                        |
-| `homepage`       | Simple static `/` HTML landing page with links to tools       |
-| `jenkins`        | CI/CD deployment automation                                   |
-| `docs/`          | Markdown documentation for each area                          |
+| Component        | Description   |
+|------------------|--------------|
+| `zammad`         | Main ticketing system   |
+| `postgresql`     | Relational database backend for Zammad   |
+| `elasticsearch`  | Search indexing backend   |
+| `nginx`          | TLS termination and reverse proxy   |
+| `certbot`        | HTTPS certificate issuance and renewal   |
+| `homepage`       | Simple static `/` HTML landing page with links to tools   |
+| `jenkins`        | CI/CD deployment automation   |
+| `docs/`          | Markdown documentation for each area   |
 
 ---
 
 ## 🔁 Pipeline & Credentials
 
 The project is deployed using a **Jenkins-based CI/CD pipeline**, configured to:
-
 - Pull from GitHub via webhook (`main` branch)
 - Build Docker images
 - Push to DockerHub
@@ -62,7 +62,6 @@ All sensitive values (IP, SSH key, domain, registry, SMTP) are passed via **Jenk
 ## 📚 Documentation Requirements
 
 For every deployed or integrated component, you must:
-
 - Create a dedicated `.md` file under `docs/`
 - Clearly explain:
   - What the service/component does
@@ -88,7 +87,6 @@ This may use:
 ## ⚙️ Service Integrity is Mandatory
 
 ✅ Every service must include:
-
 - Persistent volume definition and mounting
 - Health check and troubleshooting steps in docs
 - Instructions for restarting or reconfiguring
@@ -99,7 +97,6 @@ This may use:
 ## ✅ Deliverables Checklist for Each Service
 
 For each new component (Zammad, NGINX, Certbot, etc.), the following must be delivered:
-
 - [ ] `services/<name>/Dockerfile`
 - [ ] `docker-compose.yaml` service definition
 - [ ] Mounted volumes defined and documented
@@ -131,7 +128,7 @@ For each new component (Zammad, NGINX, Certbot, etc.), the following must be del
 3. **Documentation Format** – every guide should include the block below to remind contributors that secrets are managed by Jenkins:
 
 ```
-> **⚠️ Sensitive Keys**  
+> **⚠️ Sensitive Keys**
 > All required keys and secrets for this integration are injected securely via Jenkins and are not stored in this repository.
 ```
 
@@ -161,3 +158,7 @@ Work in the following order:
 ---
 
 Continue with the next step by checking the `/docs` directory and creating/expanding a service if it’s not complete.
+
+---
+🔗 Back to [Main README](../README.md)  
+📚 See also: [Deployment](deployment.md) | [CI/CD](ci-cd-pipeline.md)

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,8 +1,14 @@
+[← Back to Main README](../README.md)
+
 # Authentication and SSO
 
 Zammad can integrate with Microsoft 365 / Entra ID for single sign-on.
 
-> **⚠️ Sensitive Keys**  
+> **⚠️ Sensitive Keys**
 > All required keys and secrets for this integration are injected securely via Jenkins and are not stored in this repository.
 
 When implemented, configure the necessary OAuth application in Microsoft 365 and store the credentials in Jenkins. Reference these credential IDs from the pipeline to pass them into the container.
+
+---
+🔗 Back to [Main README](../README.md)  
+📚 See also: [Deployment](deployment.md) | [CI/CD](ci-cd-pipeline.md) | [Secrets](secrets.md)

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -1,0 +1,17 @@
+[← Back to Main README](../README.md)
+
+# Branding
+
+This guide explains how to customize the look and feel of the Zammad interface and the public homepage.
+
+## Customizing Zammad
+
+Zammad supports theming and custom branding through its admin interface. Upload your logo and adjust colors under **Admin → Branding**. Changes are stored in the `zammad_data` volume and take effect after refreshing the page.
+
+## Homepage Customization
+
+The landing page served by NGINX is located at `services/nginx/html/index.html`. Edit this file and rebuild the `nginx` service to apply changes.
+
+---
+🔗 Back to [Main README](../README.md)  
+📚 See also: [Deployment](deployment.md) | [Homepage](homepage.md)

--- a/docs/certbot.md
+++ b/docs/certbot.md
@@ -1,8 +1,10 @@
+[← Back to Main README](../README.md)
+
 # NGINX and Certbot Integration
 
 This guide describes how the project uses [Certbot](https://certbot.eff.org/) together with NGINX to obtain and renew free TLS certificates from Let's Encrypt.
 
-> **⚠️ Sensitive Keys**  
+> **⚠️ Sensitive Keys**
 > All required keys and secrets for this integration are injected securely via Jenkins and are not stored in this repository.
 
 ## Overview
@@ -87,10 +89,10 @@ Alternatively your Jenkins pipeline can run `docker exec certbot certbot renew` 
 
 Jenkins only stores the domain and email used for Certbot. The certificate files remain solely in the Docker volume.
 
-| Secret Name                | Purpose                                                 |
-|----------------------------|---------------------------------------------------------|
-| `remote-hostinger-domain`  | Domain pointed to the VPS                               |
-| `certbot-email`            | Email address for Let's Encrypt registration            |
+| Secret Name                | Purpose       |
+|----------------------------|---------------|
+| `remote-hostinger-domain`  | Domain pointed to the VPS       |
+| `certbot-email`            | Email address for Let's Encrypt registration       |
 
 These secrets are injected into `.env` or `docker-compose.yaml` during the pipeline so the services know which domain to use.
 
@@ -125,7 +127,7 @@ ssl_certificate /etc/letsencrypt/live/${REMOTE_DOMAIN}/fullchain.pem;
 ssl_certificate_key /etc/letsencrypt/live/${REMOTE_DOMAIN}/privkey.pem;
 ```
 
-The full NGINX configuration is stored in [`services/nginx/nginx.conf.template`](../services/nginx/nginx.conf.template) and mounts both Certbot volumes so these paths are available inside the container.
+The full NGINX configuration is stored in [`services/nginx/nginx.conf.template`](../services/nginx/nginx.conf.template) and mounts both Certbot volumes so these paths are available inside the container. See the [Deployment guide](deployment.md) for how the container is started.
 
 ## Troubleshooting
 
@@ -143,3 +145,7 @@ The full NGINX configuration is stored in [`services/nginx/nginx.conf.template`]
 - [Certbot Documentation](https://eff-certbot.readthedocs.io/en/stable/)
 - [`docker-compose.yaml`](../docker-compose.yaml)
 - [`services/nginx/nginx.conf.template`](../services/nginx/nginx.conf.template)
+
+---
+🔗 Back to [Main README](../README.md)  
+📚 See also: [Deployment](deployment.md) | [CI/CD](ci-cd-pipeline.md) | [Secrets](secrets.md)

--- a/docs/ci-cd-pipeline.md
+++ b/docs/ci-cd-pipeline.md
@@ -1,3 +1,5 @@
+[← Back to Main README](../README.md)
+
 # Jenkins CI/CD Pipeline
 
 This document explains how the Jenkins pipeline deploys the Zammad stack to a Hostinger VPS. It covers job creation, GitHub webhook configuration, credential mapping, stage explanations, and basic troubleshooting.
@@ -29,15 +31,15 @@ This is what allows Jenkins to start the pipeline whenever changes are pushed to
 
 The following Jenkins credentials are referenced in the pipeline and should be created from **Manage Jenkins → Credentials**:
 
-| Jenkins ID                              | Usage                                  |
-|-----------------------------------------|----------------------------------------|
-| `github-credentials`                    | SSH key used to pull the repository    |
-| `dockerhub-credentials`                 | Docker Hub login for pushing images    |
-| `docker-registry`                       | Docker Hub namespace/registry          |
-| `ssh-remote-server-hostinger-deploy`    | Private key for remote VPS             |
-| `remote-hostinger-deploy-ip`            | IP address of the Hostinger server     |
+| Jenkins ID                              | Usage       |
+|-----------------------------------------|-------------|
+| `github-credentials`                    | SSH key used to pull the repository |
+| `dockerhub-credentials`                 | Docker Hub login for pushing images |
+| `docker-registry`                       | Docker Hub namespace/registry |
+| `ssh-remote-server-hostinger-deploy`    | Private key for remote VPS |
+| `remote-hostinger-deploy-ip`            | IP address of the Hostinger server |
 | `remote-hostinger-domain`               | Domain name used for production deployment of Zammad |
-| `remote-user`                           | Remote Linux user (usually `root`)     |
+| `remote-user`                           | Remote Linux user (usually `root`) |
 
 ## 4. Jenkinsfile Stages
 
@@ -79,5 +81,5 @@ A successful run looks similar to:
 - The build stage only runs if a `services/` directory with Dockerfiles exists. If no custom services are needed you will only see pull and deploy steps.
 
 ---
-
-This pipeline provides an end‑to‑end automation flow: commit code → GitHub push → Jenkins build → Docker Hub push → Hostinger deployment. Edit the `Jenkinsfile` or `deploy-script.sh` to further customize the process.
+🔗 Back to [Main README](../README.md)  
+📚 See also: [Deployment](deployment.md) | [Certbot](certbot.md) | [Secrets](secrets.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,3 +1,5 @@
+[← Back to Main README](../README.md)
+
 # Deployment Guide – Zammad Docker Stack
 
 This guide explains how each service in the stack is containerised and where its data is stored. All containers connect to the `zammad-net` Docker network so they can communicate internally.
@@ -35,7 +37,7 @@ Provides search capabilities for Zammad. Built from `services/elasticsearch/Dock
 The main application container built from `services/zammad/Dockerfile`. It depends on `postgres` and `elasticsearch`. Application files and attachments are stored in `zammad_data` mounted at `/opt/zammad`.
 
 ### nginx
-Acts as the reverse proxy and exposes ports 80 and 443. It is built from `services/nginx/Dockerfile` which uses `nginx.conf.template` for its configuration. Certificates and ACME challenge files are shared with the `certbot` container via the volumes `certbot_conf` and `certbot_www`.
+Acts as the reverse proxy and exposes ports 80 and 443. It is built from `services/nginx/Dockerfile` which uses `nginx.conf.template` for its configuration. Certificates and ACME challenge files are shared with the `certbot` container via the volumes `certbot_conf` and `certbot_www`. See the [Certbot guide](certbot.md) for HTTPS configuration details.
 
 ### certbot
 Handles Let's Encrypt certificate issuance and renewal. The container is built from [`services/certbot/Dockerfile`](../services/certbot/Dockerfile), which uses the official `certbot/certbot` image as its base. It shares the same volumes as NGINX for certificate storage.
@@ -55,14 +57,15 @@ These volumes are defined in `docker-compose.yaml` and ensure data is retained a
 
 ## Running the stack
 
-1. Copy `.env.example` to `.env` and adjust values to suit your environment.
-   The `DOMAIN` entry will be replaced automatically during the Jenkins deployment
-   using the `remote-hostinger-domain` credential.
+1. Copy `.env.example` to `.env` and adjust values to suit your environment. The `DOMAIN` entry will be replaced automatically during the Jenkins deployment using the `remote-hostinger-domain` credential.
 2. Build and start the containers:
    ```bash
    docker-compose up -d
    ```
-3. The application will be available via the domain configured in your DNS pointing to the server.
-   This value is injected as `ZAMMAD_FQDN` and referenced by the NGINX configuration for TLS generation.
+3. The application will be available via the domain configured in your DNS pointing to the server. This value is injected as `ZAMMAD_FQDN` and referenced by the NGINX configuration for TLS generation.
 4. Visiting the root of your domain displays a simple welcome page with a link to `/zammad`.
 5. After the stack is online, follow the [First Run Checks](first-run-checks.md) guide to verify services and troubleshoot any issues.
+
+---
+🔗 Back to [Main README](../README.md)  
+📚 See also: [CI/CD](ci-cd-pipeline.md) | [Certbot](certbot.md) | [Secrets](secrets.md)

--- a/docs/email-integration.md
+++ b/docs/email-integration.md
@@ -1,8 +1,10 @@
+[← Back to Main README](../README.md)
+
 # Email Integration
 
 This guide explains how Zammad sends and receives email using Microsoft 365.
 
-> **⚠️ Sensitive Keys**  
+> **⚠️ Sensitive Keys**
 > All required keys and secrets for this integration are injected securely via Jenkins and are not stored in this repository.
 
 Microsoft 365 OAuth2 credentials and SMTP settings are provided via the following Jenkins secrets:
@@ -15,3 +17,7 @@ Microsoft 365 OAuth2 credentials and SMTP settings are provided via the followin
 - `m365-shared-mailbox`
 
 Configure these secrets in Jenkins and reference them in the pipeline so the Zammad container can authenticate with Microsoft 365.
+
+---
+🔗 Back to [Main README](../README.md)  
+📚 See also: [Authentication](authentication.md) | [Deployment](deployment.md) | [Secrets](secrets.md)

--- a/docs/first-run-checks.md
+++ b/docs/first-run-checks.md
@@ -1,3 +1,5 @@
+[← Back to Main README](../README.md)
+
 # First Run Checks & Troubleshooting Guide
 
 This guide helps you verify the stack after your first successful deployment and provides steps to debug common issues.
@@ -83,3 +85,6 @@ docker exec -it zammad bash
 zammad run rails c
 ```
 
+---
+🔗 Back to [Main README](../README.md)  
+📚 See also: [Troubleshooting](troubleshooting.md) | [Deployment](deployment.md)

--- a/docs/homepage.md
+++ b/docs/homepage.md
@@ -1,3 +1,5 @@
+[← Back to Main README](../README.md)
+
 # Homepage
 
 The static landing page is served by the NGINX container. It resides at `services/nginx/html/index.html` and is copied into the image during the Docker build.
@@ -8,3 +10,7 @@ Links are provided to:
 - `/status` – placeholder for health checks
 
 Edit `index.html` and rebuild the `nginx` service to change the content.
+
+---
+🔗 Back to [Main README](../README.md)  
+📚 See also: [Branding](branding.md) | [Deployment](deployment.md)

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,3 +1,5 @@
+[← Back to Main README](../README.md)
+
 # Jenkins Secrets Index
 
 The following credential IDs are referenced by the deployment pipeline. Values are stored only in Jenkins and never in this repository.
@@ -18,3 +20,7 @@ The following credential IDs are referenced by the deployment pipeline. Values a
 | `m365-smtp-user`                        | SMTP user account |
 | `m365-smtp-password`                    | SMTP password/token |
 | `m365-shared-mailbox`                   | Shared mailbox address |
+
+---
+🔗 Back to [Main README](../README.md)  
+📚 See also: [CI/CD](ci-cd-pipeline.md) | [Deployment](deployment.md)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,3 +1,5 @@
+[← Back to Main README](../README.md)
+
 # Troubleshooting
 
 Below are common issues encountered when deploying the stack.
@@ -13,3 +15,7 @@ Below are common issues encountered when deploying the stack.
 ## Database connection errors
 - Verify the `postgres` container is running and reachable.
 - Confirm credentials in `.env` match the database environment variables.
+
+---
+🔗 Back to [Main README](../README.md)  
+📚 See also: [First Run Checks](first-run-checks.md) | [Deployment](deployment.md)

--- a/docs/zammad.md
+++ b/docs/zammad.md
@@ -1,3 +1,5 @@
+[← Back to Main README](../README.md)
+
 # Zammad Service
 
 Zammad provides the ticketing UI and API. The container is built from `services/zammad/Dockerfile` and depends on the `postgres` and `elasticsearch` services.
@@ -22,3 +24,7 @@ If the service fails to start:
 - Check connectivity to the database and elasticsearch containers.
 - Review logs with `docker logs zammad`.
 - Ensure permissions on the `zammad_data` volume allow write access.
+
+---
+🔗 Back to [Main README](../README.md)  
+📚 See also: [Deployment](deployment.md) | [First Run Checks](first-run-checks.md)


### PR DESCRIPTION
## Summary
- rename docs for clarity and add `branding.md`
- rewrite README with quick start and updated doc links
- interlink all docs with standard header and footer
- describe documentation standards in `agent_prompt.md`

## Testing
- `git log -1 --stat`
- `[ -f Makefile ] && make test || echo 'no tests'`

------
https://chatgpt.com/codex/tasks/task_e_68631d3a3f7c832cbd5a7b15558040a5