### PR TITLE
Add Jenkins SSH setup requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This repository represents my first step into the world of open-source collabora
    - A record must point to your server's IP.
 3. **Jenkins CI/CD**
    - Handles deployment and injects secrets such as SSH keys, domain details and DockerHub credentials.
+   - Prepare the Jenkins host for SSH as described in [Jenkins SSH Setup on Host Machine](docs/first-run.md#-jenkins-ssh-setup-on-host-machine).
 4. **Azure Tenant with Admin Access**
    - Required for Microsoft 365 shared mailboxes, Entra ID authentication and Teams/SharePoint integrations.
 

--- a/docs/ci-cd-pipeline.md
+++ b/docs/ci-cd-pipeline.md
@@ -75,6 +75,7 @@ A successful run looks similar to:
 
 **Permission denied during SSH**
 - Confirm the credential `ssh-remote-server-hostinger-deploy` contains a valid private key and that the public key is in `~/.ssh/authorized_keys` on the VPS.
+- Ensure the Jenkins host itself is prepared as described in [Jenkins SSH Setup on Host Machine](first-run.md#-jenkins-ssh-setup-on-host-machine).
 
 **Docker push fails**
 - Check that the credentials `dockerhub-credentials` are correct and that the Jenkins server has outbound internet access.

--- a/docs/first-run-checks.md
+++ b/docs/first-run-checks.md
@@ -44,7 +44,7 @@ docker exec -it postgres psql -U postgres
 | Zammad container crashes | No DB | Is Postgres healthy? | Restart stack |
 | NGINX shows bad gateway | Wrong proxy port | Check NGINX logs | Fix reverse proxy config |
 | Certbot failed | Domain/IP not pointing to VPS | `docker logs certbot` | Fix DNS or rerun deploy |
-| Jenkins can't SSH | Credential issue | Check Jenkins logs | Rebind SSH key |
+| Jenkins can't SSH | Credential issue | Check Jenkins logs | Rebind SSH key and confirm [Jenkins SSH Setup on Host Machine](first-run.md#-jenkins-ssh-setup-on-host-machine) |
 
 ## 🧪 Testing Endpoints
 

--- a/docs/first-run.md
+++ b/docs/first-run.md
@@ -6,6 +6,27 @@
 
 This guide collects notes and fixes for your very first deployment. Follow the [Deployment guide](deployment.md) then review the checks below.
 
+## 🔐 Jenkins SSH Setup on Host Machine
+
+To allow the pipeline's `ssh` and `scp` steps to run correctly, the Jenkins host must have its SSH directory prepared **before the first build**:
+
+```bash
+# Create .ssh directory if it doesn't exist
+sudo mkdir -p /var/lib/jenkins/.ssh
+sudo chown jenkins:jenkins /var/lib/jenkins/.ssh
+sudo chmod 700 /var/lib/jenkins/.ssh
+
+# Create empty known_hosts file
+sudo touch /var/lib/jenkins/.ssh/known_hosts
+sudo chown jenkins:jenkins /var/lib/jenkins/.ssh/known_hosts
+sudo chmod 644 /var/lib/jenkins/.ssh/known_hosts
+
+# Restart Jenkins after change
+sudo systemctl restart jenkins
+```
+
+Perform this step only once as part of preparing the Jenkins node. It ensures SSH based deployments succeed and prevents `Permission denied` or `Failed to add host to known_hosts` errors.
+
 ## 🐛 Common Errors During First Run
 
 ### Certbot Fails with RecursionError
@@ -56,6 +77,8 @@ chmod 600 /var/lib/jenkins/.ssh/known_hosts
 ```
 
 This removes interactive prompts and lets Jenkins connect non‑interactively.
+
+If this step still fails, confirm you've completed the [Jenkins SSH Setup on Host Machine](#-jenkins-ssh-setup-on-host-machine).
 
 ### Certbot Challenge Errors
 


### PR DESCRIPTION
## Summary
- document Jenkins host SSH preparation steps
- link Jenkins SSH requirement from README requirements
- reference the new section in CI/CD pipeline and troubleshooting docs
- note the SSH setup cross-link in first-run guide

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68641f9bedb4832cad726bc0c9e32f8a