### PR TITLE
Fix nginx restart loop & update docs

### DIFF
--- a/docs/certbot.md
+++ b/docs/certbot.md
@@ -26,7 +26,7 @@ On the server these volumes are managed by Docker and typically live under `/var
 
 ## Webroot Validation Setup
 
-Before requesting a certificate, verify that NGINX serves the challenge directory and that the Certbot container can write to it. In `services/nginx/default.conf.template` you should see:
+Before requesting a certificate, verify that NGINX serves the challenge directory and that the Certbot container can write to it. In `services/nginx/conf.d/default.conf.template` you should see:
 
 ```nginx
 location /.well-known/acme-challenge/ {
@@ -159,7 +159,7 @@ ssl_certificate /etc/letsencrypt/live/${REMOTE_DOMAIN}/fullchain.pem;
 ssl_certificate_key /etc/letsencrypt/live/${REMOTE_DOMAIN}/privkey.pem;
 ```
 
-The full NGINX configuration is stored in [`services/nginx/default.conf.template`](../services/nginx/default.conf.template) and mounts the Certbot volumes so these paths are available inside the container. See the [Deployment guide](deployment.md) for how the container is started.
+The full NGINX configuration is stored in [`services/nginx/conf.d/default.conf.template`](../services/nginx/conf.d/default.conf.template) and mounts the Certbot volumes so these paths are available inside the container. See the [Deployment guide](deployment.md) for how the container is started.
 
 ## Troubleshooting
 
@@ -181,7 +181,7 @@ The full NGINX configuration is stored in [`services/nginx/default.conf.template
 
 - [Certbot Documentation](https://eff-certbot.readthedocs.io/en/stable/)
 - [`docker-compose.yaml`](../docker-compose.yaml)
-- [`services/nginx/nginx.conf.template`](../services/nginx/nginx.conf.template)
+- [`services/nginx/nginx.conf`](../services/nginx/nginx.conf)
 
 ---
 🔗 Back to [Main README](../README.md)  

--- a/docs/nginx-certbot.md
+++ b/docs/nginx-certbot.md
@@ -11,7 +11,7 @@ services/nginx/              # Dockerfile and config templates
 certbot/www/                 # ACME challenge files served by NGINX
 ```
 
-NGINX loads global settings from `services/nginx/nginx.conf` and includes all files under `/etc/nginx/conf.d/`. The main virtual host logic is rendered from `default.conf.template` (HTTPS) or `default.http.conf.template` when no certificate exists.
+NGINX loads global settings from `services/nginx/nginx.conf` and includes all files under `/etc/nginx/conf.d/`. The main virtual host logic is rendered from `conf.d/default.conf.template` (HTTPS) or `conf.d/default.http.conf.template` when no certificate exists.
 
 ## Cloudflare Proxy Warning
 
@@ -42,6 +42,22 @@ Both commands should output `hello`.
 ```
 
 If the test file is reachable, Certbot will obtain the certificate and NGINX will automatically reload.
+
+## Troubleshooting `"server" directive is not allowed here`
+
+If NGINX fails to start with an error like:
+
+```
+nginx: [emerg] "server" directive is not allowed here in /etc/nginx/nginx.conf:1
+```
+
+it means a `server {}` block was placed directly inside `nginx.conf`. Only global settings and the `http {}` block belong in that file. Move any `server {}` block into its own file under `/etc/nginx/conf.d/` (for example `default.conf`). After adjusting the files, test the configuration inside the container:
+
+```bash
+nginx -t
+```
+
+This command should report `syntax is ok` and `test is successful`.
 
 ---
 🔗 Back to [Main README](../README.md)

--- a/services/nginx/Dockerfile
+++ b/services/nginx/Dockerfile
@@ -2,8 +2,8 @@
 FROM nginx:alpine
 
 COPY nginx.conf /etc/nginx/nginx.conf
-COPY default.conf.template /etc/nginx/default.conf.template
-COPY default.http.conf.template /etc/nginx/default.http.conf.template
+COPY default.conf.template /etc/nginx/conf.d/default.conf.template
+COPY default.http.conf.template /etc/nginx/conf.d/default.http.conf.template
 COPY html /usr/share/nginx/html
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/services/nginx/docker-entrypoint.sh
+++ b/services/nginx/docker-entrypoint.sh
@@ -5,10 +5,10 @@ CERT_PATH="/etc/letsencrypt/live/${REMOTE_DOMAIN}/fullchain.pem"
 CONF_DIR="/etc/nginx/conf.d"
 mkdir -p "$CONF_DIR"
 if [ -f "$CERT_PATH" ]; then
-    envsubst '$REMOTE_DOMAIN' < /etc/nginx/default.conf.template > "$CONF_DIR/default.conf"
+    envsubst '$REMOTE_DOMAIN' < /etc/nginx/conf.d/default.conf.template > "$CONF_DIR/default.conf"
 else
     echo "Using temporary HTTP config until certificate exists"
-    envsubst '$REMOTE_DOMAIN' < /etc/nginx/default.http.conf.template > "$CONF_DIR/default.conf"
+    envsubst '$REMOTE_DOMAIN' < /etc/nginx/conf.d/default.http.conf.template > "$CONF_DIR/default.conf"
 fi
 nginx -t
 exec nginx -g 'daemon off;'


### PR DESCRIPTION
## Summary
- copy default nginx templates into conf.d
- adjust nginx entrypoint to write conf.d/default.conf
- document fix for `server` directive error in nginx
- update certbot docs with new template paths

## Testing
- `sh -n deploy-script.sh`
- `sh -n services/nginx/docker-entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_68643520d0e8832c8bd7d51ef6b45294