### PR TITLE
Fix ACME challenge path

### DIFF
--- a/docs/certbot-setup.md
+++ b/docs/certbot-setup.md
@@ -17,8 +17,8 @@ Certbot obtains TLS certificates from Let's Encrypt. This stack uses the **webro
 NGINX must serve the challenge directory without redirecting it to HTTPS:
 
 ```nginx
-location ^~ /.well-known/acme-challenge/ {
-    root /var/www/certbot;
+location /.well-known/acme-challenge/ {
+    alias /var/www/certbot/;
 }
 ```
 

--- a/docs/certbot.md
+++ b/docs/certbot.md
@@ -30,7 +30,7 @@ Before requesting a certificate, verify that NGINX serves the challenge director
 
 ```nginx
 location /.well-known/acme-challenge/ {
-    root /var/www/certbot;
+    alias /var/www/certbot/;
 }
 ```
 

--- a/docs/nginx-certbot.md
+++ b/docs/nginx-certbot.md
@@ -38,7 +38,7 @@ Make sure the HTTP server block serves the challenge directory without redirects
 
 ```nginx
 location /.well-known/acme-challenge/ {
-    root /var/www/certbot;
+    alias /var/www/certbot/;
 }
 ```
 

--- a/services/nginx/default.conf.template
+++ b/services/nginx/default.conf.template
@@ -3,7 +3,7 @@ server {
     server_name ${REMOTE_DOMAIN};
 
     location /.well-known/acme-challenge/ {
-        root /var/www/certbot;
+        alias /var/www/certbot/;
     }
 
     location / {

--- a/services/nginx/default.http.conf.template
+++ b/services/nginx/default.http.conf.template
@@ -3,7 +3,7 @@ server {
     server_name ${REMOTE_DOMAIN};
 
     location /.well-known/acme-challenge/ {
-        root /var/www/certbot;
+        alias /var/www/certbot/;
     }
 
     location / {


### PR DESCRIPTION
## Summary
- serve the ACME challenge directory via `alias`
- update docs for new nginx alias configuration

## Testing
- `docker-compose --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643f117d70832cb654a78353947527