### PR TITLE
Add certbot debug helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ All additional guides are stored in the [`docs/`](docs/) directory:
 - **[branding.md](docs/branding.md)** – Customization and UI theming.
 - **[certbot.md](docs/certbot.md)** – HTTPS setup with Certbot.
 - **[certbot-setup.md](docs/certbot-setup.md)** – How ACME HTTP-01 works and troubleshooting tips.
+- **[certbot-debug.md](docs/certbot-debug.md)** – Run a standalone Certbot container for manual testing.
 - **[nginx-certbot.md](docs/nginx-certbot.md)** – NGINX proxy configuration and Cloudflare notes.
 - **[secrets.md](docs/secrets.md)** – Overview of Jenkins credential IDs.
 - **[first-run.md](docs/first-run.md)** – Troubleshoot common first-run errors, including [Certbot failures](docs/first-run.md#-common-certbot-failures-and-how-to-fix-them).

--- a/certbot-debug.sh
+++ b/certbot-debug.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <domain> <email>"
+    exit 1
+fi
+
+DOMAIN="$1"
+EMAIL="$2"
+
+docker run --rm -it \
+  -v certbot_conf:/etc/letsencrypt \
+  -v certbot_webroot:/var/www/certbot \
+  certbot/certbot certonly --webroot \
+  --webroot-path /var/www/certbot \
+  -d "$DOMAIN" \
+  --email "$EMAIL" \
+  --agree-tos \
+  --no-eff-email \
+  --debug-challenges \
+  --dry-run -v

--- a/docs/certbot-debug.md
+++ b/docs/certbot-debug.md
@@ -1,0 +1,27 @@
+[← Back to Main README](../README.md)
+
+# Certbot Debugging Guide
+
+This guide shows how to run a standalone Certbot container for manual testing. It uses the same volumes as the main stack so you can inspect the ACME challenge files.
+
+## Usage
+
+Run the helper script from the repository root:
+
+```bash
+./certbot-debug.sh yourdomain.com you@example.com
+```
+
+The script launches the official `certbot/certbot` image with the `certbot_conf` and `certbot_webroot` volumes mounted. It performs a `--dry-run` certificate request and enables `--debug-challenges` so you can see the challenge file inside `/var/www/certbot`.
+
+While the script is running, open another terminal and verify that NGINX serves the challenge file:
+
+```bash
+curl http://yourdomain.com/.well-known/acme-challenge/<token>
+```
+
+Press `Ctrl+C` to stop the script or let Certbot finish. No real certificate is issued because the `--dry-run` option uses the Let's Encrypt staging environment.
+
+---
+🔗 Back to [Main README](../README.md)
+📚 See also: [certbot.md](certbot.md) | [certbot-setup.md](certbot-setup.md)

--- a/docs/certbot.md
+++ b/docs/certbot.md
@@ -164,7 +164,7 @@ The full NGINX configuration is stored in [`services/nginx/conf.d/default.conf.t
 ## Troubleshooting
 
 - **Certificate not renewing** – check the Certbot logs with `docker logs certbot`. Errors usually indicate network or DNS issues.
-- **Manually rerun** – if renewal fails repeatedly you can rerun the one‑time command:
+- **Manually rerun** – if renewal fails repeatedly you can rerun the one‑time command or use the [debug script](certbot-debug.md) to inspect the ACME challenge:
   ```bash
   docker run --rm -v certbot_conf:/etc/letsencrypt \
     -v ./certbot/www:/var/www/certbot \
@@ -184,5 +184,5 @@ The full NGINX configuration is stored in [`services/nginx/conf.d/default.conf.t
 - [`services/nginx/nginx.conf`](../services/nginx/nginx.conf)
 
 ---
-🔗 Back to [Main README](../README.md)  
-📚 See also: [Deployment](deployment.md) | [CI/CD](ci-cd-pipeline.md) | [Secrets](secrets.md)
+🔗 Back to [Main README](../README.md)
+📚 See also: [certbot-debug](certbot-debug.md) | [Deployment](deployment.md) | [CI/CD](ci-cd-pipeline.md) | [Secrets](secrets.md)


### PR DESCRIPTION
## Summary
- add `certbot-debug.sh` helper script
- document how to run a manual Certbot container in `certbot-debug.md`
- link the new guide in README and `certbot.md`

## Testing
- `bash -n certbot-debug.sh`
- `shellcheck certbot-debug.sh`
- `docker-compose config`

------
https://chatgpt.com/codex/tasks/task_e_686442a950e4832cbd6980a6f9885d2c