### PR TITLE
Fix initial HTTPS setup

### DIFF
--- a/deploy-script.sh
+++ b/deploy-script.sh
@@ -49,7 +49,12 @@ if [ -n "$CERTBOT_EMAIL_ARG" ]; then
 elif [ -n "${CERTBOT_EMAIL:-}" ]; then
     CERTBOT_EMAIL="$CERTBOT_EMAIL"
 else
-    CERTBOT_EMAIL=$(grep '^CERTBOT_EMAIL=' .env | cut -d '=' -f2)
+    if [ -f .env ]; then
+        CERTBOT_EMAIL=$(grep '^CERTBOT_EMAIL=' .env | cut -d '=' -f2 || true)
+    else
+        echo "❌ CERTBOT_EMAIL not set. Provide as argument or via CERTBOT_EMAIL env variable."
+        exit 1
+    fi
 fi
 
 # Bootstrap certificate if it doesn't already exist
@@ -78,6 +83,9 @@ if [ ! -d "$CERT_PATH/live/$REMOTE_DOMAIN" ]; then
       --agree-tos \
       --email "$CERTBOT_EMAIL" \
       --no-eff-email
+
+    echo "🔄 Restarting nginx to apply HTTPS config"
+    docker-compose restart nginx
 fi
 
 # Pull and run containers

--- a/docs/certbot.md
+++ b/docs/certbot.md
@@ -77,6 +77,12 @@ docker run --rm \
 
 Port **80** must be reachable and NGINX must route `/.well-known/acme-challenge/` to `/var/www/certbot` for this step to succeed. Certificates are stored under `/etc/letsencrypt/live/yourdomain.com/` inside the `certbot_conf` volume.
 
+After the certificate is issued, restart NGINX so the HTTPS configuration is loaded:
+
+```bash
+docker-compose restart nginx
+```
+
 ### Using the Certificates in NGINX
 
 Mount the `certbot_conf` volume in the NGINX service so the certificates are available without copying them into Jenkins:


### PR DESCRIPTION
## Summary
- restart nginx after certbot obtains the first certificate
- ensure deploy script fails clearly if CERTBOT_EMAIL is missing
- note nginx restart in the Certbot guide

## Testing
- `shellcheck deploy-script.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a54b902bc832cb4ee632e15dab102