### PR TITLE
Fix secret interpolation in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,8 +24,8 @@ pipeline {
                             for (service in services) {
                                 if (fileExists("${servicesDir}/${service}/Dockerfile")) {
                                     sh """
-                                        docker build -t ${DOCKER_REGISTRY}/${service}:latest ${servicesDir}/${service}
-                                        docker tag ${DOCKER_REGISTRY}/${service}:latest ${DOCKER_REGISTRY}/${service}:${BUILD_NUMBER}
+                                        docker build -t \$DOCKER_REGISTRY/${service}:latest ${servicesDir}/${service}
+                                        docker tag \$DOCKER_REGISTRY/${service}:latest \$DOCKER_REGISTRY/${service}:${BUILD_NUMBER}
                                     """
                                 }
                             }
@@ -49,8 +49,8 @@ pipeline {
                             for (service in services) {
                                 if (fileExists("${servicesDir}/${service}/Dockerfile")) {
                                     sh """
-                                        docker push ${DOCKER_REGISTRY}/${service}:latest
-                                        docker push ${DOCKER_REGISTRY}/${service}:${BUILD_NUMBER}
+                                        docker push \$DOCKER_REGISTRY/${service}:latest
+                                        docker push \$DOCKER_REGISTRY/${service}:${BUILD_NUMBER}
                                     """
                                 }
                             }


### PR DESCRIPTION
## Summary
- avoid Groovy string interpolation for DOCKER_REGISTRY

## Testing
- *(no tests in repo)*
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a57eafca8832cbec360f60f373bc7