### PR TITLE
Clarify certbot webroot in docs

### DIFF
--- a/docs/certbot-setup.md
+++ b/docs/certbot-setup.md
@@ -26,8 +26,12 @@ This block should appear **before** any other redirect rules. The NGINX and Cert
 
 ```yaml
 volumes:
-  - ./certbot/www:/var/www/certbot
+  - certbot_webroot:/var/www/certbot
 ```
+
+> **Note:** The `.well-known/acme-challenge/` path is mapped via `alias` in
+> NGINX. You will not see that directory inside the container. Files created in
+> the `certbot_webroot` volume appear directly under `/var/www/certbot/`.
 
 ## Cloudflare Proxy Considerations
 
@@ -38,7 +42,7 @@ If your DNS uses Cloudflare, disable the orange cloud (HTTP proxy) during certif
 Create a test file in the shared volume and verify it from outside the server:
 
 ```bash
-docker run --rm -v ./certbot/www:/var/www/certbot busybox sh -c 'echo hello > /var/www/certbot/test.txt'
+docker run --rm -v certbot_webroot:/var/www/certbot busybox sh -c 'echo hello > /var/www/certbot/test.txt'
 curl http://<domain>/.well-known/acme-challenge/test.txt
 ```
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -39,7 +39,7 @@ Provides search capabilities for Zammad. Built from `services/elasticsearch/Dock
 The main application container built from `services/zammad/Dockerfile`. It depends on `postgres` and `elasticsearch`. Application files and attachments are stored in `zammad_data` mounted at `/opt/zammad`.
 
 ### nginx
-Acts as the reverse proxy and exposes ports 80 and 443. It is built from `services/nginx/Dockerfile` which uses template files for its configuration. Certificates are stored in the `certbot_conf` volume and ACME challenge files are served from the local directory `./certbot/www`. See the [Certbot guide](certbot.md) for HTTPS configuration details.
+Acts as the reverse proxy and exposes ports 80 and 443. It is built from `services/nginx/Dockerfile` which uses template files for its configuration. Certificates are stored in the `certbot_conf` volume and ACME challenge files are served from the `certbot_webroot` volume mounted at `/var/www/certbot`. See the [Certbot guide](certbot.md) for HTTPS configuration details.
 
 ### certbot
 Handles Let's Encrypt certificate issuance and renewal. The container is built from [`services/certbot/Dockerfile`](../services/certbot/Dockerfile), which uses the official `certbot/certbot` image as its base. It shares the same volumes as NGINX for certificate storage.

--- a/docs/first-run.md
+++ b/docs/first-run.md
@@ -95,7 +95,7 @@ These errors typically appear during the first certificate request. Use the chec
    docker exec nginx curl -s localhost/.well-known/acme-challenge/testfile
    docker exec certbot ls /var/www/certbot
    ```
-   All commands must succeed. If they fail, confirm that both containers share the `./certbot/www` directory.
+   All commands must succeed. If they fail, confirm that both containers share the `certbot_webroot` volume.
 3. **Cloudflare or firewall interference** – temporarily disable any proxies and open port 80 directly to the server.
 
 If any step fails, fix the issue before launching Certbot again.


### PR DESCRIPTION
## Summary
- document that `.well-known` is served from the `certbot_webroot` volume
- update instructions to use the `certbot_webroot` volume
- fix deployment guide reference to the certbot volume
- tweak first-run checklist

## Testing
- `markdownlint docs/*.md`

------
https://chatgpt.com/codex/tasks/task_e_687a701417dc832cbe0b2ca0d35b7b64