### PR TITLE
Add generic config fallback helper

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,9 @@ volumes:
 
 services:
   postgres:
-    build: ./services/postgres
+    build:
+      context: ./services
+      dockerfile: postgres/Dockerfile
     image: ${DOCKER_REGISTRY}/postgres:latest
     restart: unless-stopped
     environment:
@@ -25,7 +27,9 @@ services:
       - zammad-net
 
   elasticsearch:
-    build: ./services/elasticsearch
+    build:
+      context: ./services
+      dockerfile: elasticsearch/Dockerfile
     image: ${DOCKER_REGISTRY}/elasticsearch:latest
     restart: unless-stopped
     environment:
@@ -37,7 +41,9 @@ services:
       - zammad-net
 
   zammad:
-    build: ./services/zammad
+    build:
+      context: ./services
+      dockerfile: zammad/Dockerfile
     image: ${DOCKER_REGISTRY}/zammad:latest
     restart: unless-stopped
     depends_on:
@@ -56,7 +62,9 @@ services:
       - zammad-net
 
   nginx:
-    build: ./services/nginx
+    build:
+      context: ./services
+      dockerfile: nginx/Dockerfile
     image: ${DOCKER_REGISTRY}/nginx:latest
     restart: unless-stopped
     depends_on:
@@ -73,7 +81,9 @@ services:
       - zammad-net
 
   certbot:
-    build: ./services/certbot
+    build:
+      context: ./services
+      dockerfile: certbot/Dockerfile
     image: ${DOCKER_REGISTRY}/certbot:latest
     restart: unless-stopped
     volumes:

--- a/docs/nginx-certbot.md
+++ b/docs/nginx-certbot.md
@@ -10,7 +10,7 @@ This guide explains how the NGINX reverse proxy and Certbot container work toget
 services/nginx/              # Dockerfile and config templates
 ```
 
-NGINX loads global settings from `services/nginx/nginx.conf` and includes all files under `/etc/nginx/conf.d/`. The main virtual host logic is rendered from `conf.d/default.conf.template` (HTTPS) or `conf.d/default.http.conf.template` when no certificate exists.
+NGINX loads global settings from `services/nginx/nginx.conf` and includes all files under `/etc/nginx/conf.d/`. During container start the entrypoint checks if `/etc/nginx/conf.d/default.conf` exists. If not, it generates one from `conf.d/default.conf.template` (HTTPS) or `conf.d/default.http.conf.template` when no certificate is present. This behaviour is handled by the helper script `ensure-config.sh` and lets you mount your own `default.conf` to override the template.
 
 ## Volume Mount Strategy
 
@@ -110,3 +110,4 @@ This command should report `syntax is ok` and `test is successful`.
 ---
 🔗 Back to [Main README](../README.md)
 📚 See also: [certbot.md](certbot.md) | [deployment](deployment.md)
+

--- a/services/common/ensure-config.sh
+++ b/services/common/ensure-config.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+# Usage: ensure-config.sh <template> <target> [vars]
+TEMPLATE="$1"
+TARGET="$2"
+shift 2
+VARS="$*"
+
+if [ ! -f "$TARGET" ]; then
+  echo "Generating $TARGET from $(basename "$TEMPLATE")"
+  if [ -n "$VARS" ]; then
+    envsubst "$VARS" < "$TEMPLATE" > "$TARGET"
+  else
+    cp "$TEMPLATE" "$TARGET"
+  fi
+else
+  echo "Using existing $TARGET"
+fi

--- a/services/nginx/Dockerfile
+++ b/services/nginx/Dockerfile
@@ -1,12 +1,13 @@
 # Nginx reverse proxy Dockerfile
 FROM nginx:alpine
 
-COPY nginx.conf /etc/nginx/nginx.conf
-COPY default.conf.template /etc/nginx/conf.d/default.conf.template
-COPY default.http.conf.template /etc/nginx/conf.d/default.http.conf.template
-COPY html /usr/share/nginx/html
-COPY docker-entrypoint.sh /docker-entrypoint.sh
-RUN chmod +x /docker-entrypoint.sh
+COPY nginx/nginx.conf /etc/nginx/nginx.conf
+COPY nginx/default.conf.template /etc/nginx/conf.d/default.conf.template
+COPY nginx/default.http.conf.template /etc/nginx/conf.d/default.http.conf.template
+COPY nginx/html /usr/share/nginx/html
+COPY nginx/docker-entrypoint.sh /docker-entrypoint.sh
+COPY common/ensure-config.sh /usr/local/bin/ensure-config.sh
+RUN chmod +x /usr/local/bin/ensure-config.sh /docker-entrypoint.sh
 
 VOLUME ["/var/www/certbot", "/etc/letsencrypt"]
 

--- a/services/nginx/docker-entrypoint.sh
+++ b/services/nginx/docker-entrypoint.sh
@@ -3,12 +3,19 @@ set -e
 # substitute domain into config
 CERT_PATH="/etc/letsencrypt/live/${REMOTE_DOMAIN}/fullchain.pem"
 CONF_DIR="/etc/nginx/conf.d"
+CONF_FILE="$CONF_DIR/default.conf"
 mkdir -p "$CONF_DIR"
-if [ -f "$CERT_PATH" ]; then
-    envsubst '$REMOTE_DOMAIN' < /etc/nginx/conf.d/default.conf.template > "$CONF_DIR/default.conf"
+
+if [ ! -f "$CONF_FILE" ]; then
+    if [ -f "$CERT_PATH" ]; then
+        /usr/local/bin/ensure-config.sh /etc/nginx/conf.d/default.conf.template "$CONF_FILE" '$REMOTE_DOMAIN'
+    else
+        echo "Using temporary HTTP config until certificate exists"
+        /usr/local/bin/ensure-config.sh /etc/nginx/conf.d/default.http.conf.template "$CONF_FILE" '$REMOTE_DOMAIN'
+    fi
 else
-    echo "Using temporary HTTP config until certificate exists"
-    envsubst '$REMOTE_DOMAIN' < /etc/nginx/conf.d/default.http.conf.template > "$CONF_DIR/default.conf"
+    echo "Using existing $CONF_FILE"
 fi
+
 nginx -t
 exec nginx -g 'daemon off;'


### PR DESCRIPTION
## Summary
- add `ensure-config.sh` helper for config fallback
- update nginx entrypoint to use helper and respect existing configs
- modify `docker-compose.yaml` build contexts for shared resources
- document nginx config fallback logic

## Testing
- `shellcheck services/common/ensure-config.sh services/nginx/docker-entrypoint.sh`
- `apt-get install -y shellcheck`

------
https://chatgpt.com/codex/tasks/task_e_687a76aaa0b4832c8fa954b87092dcdf