### PR TITLE
Handle missing nginx.conf during build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
                             for (service in services) {
                                 if (fileExists("${servicesDir}/${service}/Dockerfile")) {
                                     sh """
-                                        docker build -t \$DOCKER_REGISTRY/${service}:latest ${servicesDir}/${service}
+                                        docker build -t \$DOCKER_REGISTRY/${service}:latest -f ${servicesDir}/${service}/Dockerfile ${servicesDir}
                                         docker tag \$DOCKER_REGISTRY/${service}:latest \$DOCKER_REGISTRY/${service}:${BUILD_NUMBER}
                                     """
                                 }

--- a/docs/nginx-certbot.md
+++ b/docs/nginx-certbot.md
@@ -10,7 +10,7 @@ This guide explains how the NGINX reverse proxy and Certbot container work toget
 services/nginx/              # Dockerfile and config templates
 ```
 
-NGINX loads global settings from `services/nginx/nginx.conf` and includes all files under `/etc/nginx/conf.d/`. During container start the entrypoint checks if `/etc/nginx/conf.d/default.conf` exists. If not, it generates one from `conf.d/default.conf.template` (HTTPS) or `conf.d/default.http.conf.template` when no certificate is present. This behaviour is handled by the helper script `ensure-config.sh` and lets you mount your own `default.conf` to override the template.
+NGINX loads global settings from `services/nginx/nginx.conf` and includes all files under `/etc/nginx/conf.d/`. If `nginx.conf` is missing when the image is built, the Dockerfile falls back to `nginx.conf.template` and prints a warning. During container start the entrypoint checks if `/etc/nginx/conf.d/default.conf` exists. If not, it generates one from `conf.d/default.conf.template` (HTTPS) or `conf.d/default.http.conf.template` when no certificate is present. This behaviour is handled by the helper script `ensure-config.sh` and lets you mount your own `default.conf` to override the template.
 
 ## Volume Mount Strategy
 

--- a/services/nginx/Dockerfile
+++ b/services/nginx/Dockerfile
@@ -1,13 +1,24 @@
 # Nginx reverse proxy Dockerfile
 FROM nginx:alpine
 
-COPY nginx/nginx.conf /etc/nginx/nginx.conf
-COPY nginx/default.conf.template /etc/nginx/conf.d/default.conf.template
-COPY nginx/default.http.conf.template /etc/nginx/conf.d/default.http.conf.template
-COPY nginx/html /usr/share/nginx/html
-COPY nginx/docker-entrypoint.sh /docker-entrypoint.sh
+# Copy entire nginx directory so we can conditionally select files
+COPY nginx /tmp/nginx
 COPY common/ensure-config.sh /usr/local/bin/ensure-config.sh
-RUN chmod +x /usr/local/bin/ensure-config.sh /docker-entrypoint.sh
+
+RUN chmod +x /usr/local/bin/ensure-config.sh /tmp/nginx/docker-entrypoint.sh \
+    && if [ -f /tmp/nginx/nginx.conf ]; then \
+         echo "✅ Using provided nginx.conf"; \
+         cp /tmp/nginx/nginx.conf /etc/nginx/nginx.conf; \
+       else \
+         echo "⚠️  nginx.conf not found, using template"; \
+         cp /tmp/nginx/nginx.conf.template /etc/nginx/nginx.conf; \
+       fi \
+    && cp /tmp/nginx/default.conf.template /etc/nginx/conf.d/default.conf.template \
+    && cp /tmp/nginx/default.http.conf.template /etc/nginx/conf.d/default.http.conf.template \
+    && cp -r /tmp/nginx/html /usr/share/nginx/html \
+    && mv /tmp/nginx/docker-entrypoint.sh /docker-entrypoint.sh \
+    && chmod +x /docker-entrypoint.sh \
+    && rm -rf /tmp/nginx
 
 VOLUME ["/var/www/certbot", "/etc/letsencrypt"]
 

--- a/services/nginx/nginx.conf.template
+++ b/services/nginx/nginx.conf.template
@@ -1,0 +1,16 @@
+user  nginx;
+worker_processes auto;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    sendfile        on;
+    keepalive_timeout  65;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
## Summary
- tweak Jenkins build step to use services as build context
- copy nginx directory in Dockerfile and fallback to nginx.conf.template
- add nginx.conf.template to provide default configuration
- document nginx.conf template fallback

## Testing
- `markdownlint docs/*.md README.md` *(fails: various MD013, MD032, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687a79893abc832c8664a362ffb48dbb