### PR TITLE
Fix default NGINX template path

### DIFF
--- a/docs/certbot.md
+++ b/docs/certbot.md
@@ -26,7 +26,7 @@ On the server these volumes are managed by Docker and typically live under `/var
 
 ## Webroot Validation Setup
 
-Before requesting a certificate, verify that NGINX serves the challenge directory and that the Certbot container can write to it. In `services/nginx/conf.d/default.conf.template` you should see:
+Before requesting a certificate, verify that NGINX serves the challenge directory and that the Certbot container can write to it. In `services/nginx/default.conf.template` you should see:
 
 ```nginx
 location /.well-known/acme-challenge/ {
@@ -165,7 +165,7 @@ ssl_certificate /etc/letsencrypt/live/${REMOTE_DOMAIN}/fullchain.pem;
 ssl_certificate_key /etc/letsencrypt/live/${REMOTE_DOMAIN}/privkey.pem;
 ```
 
-The full NGINX configuration is stored in [`services/nginx/conf.d/default.conf.template`](../services/nginx/conf.d/default.conf.template) and mounts the Certbot volumes so these paths are available inside the container. See the [Deployment guide](deployment.md) for how the container is started.
+The full NGINX configuration is stored in [`services/nginx/default.conf.template`](../services/nginx/default.conf.template) and mounts the Certbot volumes so these paths are available inside the container. See the [Deployment guide](deployment.md) for how the container is started.
 
 ## Troubleshooting
 

--- a/services/nginx/Dockerfile
+++ b/services/nginx/Dockerfile
@@ -13,6 +13,7 @@ RUN chmod +x /usr/local/bin/ensure-config.sh /tmp/nginx/docker-entrypoint.sh \
          echo "⚠️  nginx.conf not found, using default.conf.template"; \
          cp /tmp/nginx/default.conf.template /etc/nginx/nginx.conf; \
        fi \
+    && cp /tmp/nginx/default.conf.template /etc/nginx/conf.d/default.conf.template \
     && cp /tmp/nginx/default.http.conf.template /etc/nginx/conf.d/default.http.conf.template \
     && cp -r /tmp/nginx/html /usr/share/nginx/html \
     && mv /tmp/nginx/docker-entrypoint.sh /docker-entrypoint.sh \


### PR DESCRIPTION
## Summary
- ensure `default.conf.template` gets copied into `/etc/nginx/conf.d`
- update docs to reference `services/nginx/default.conf.template`

## Testing
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a80b0d42c832c9ead57259538f75b