### PR TITLE
Document fix for missing Certbot challenge block

### DIFF
--- a/docs/first-run.md
+++ b/docs/first-run.md
@@ -97,6 +97,14 @@ These errors typically appear during the first certificate request. Use the chec
    ```
    All commands must succeed. If they fail, confirm that both containers share the `certbot_webroot` volume.
 3. **Cloudflare or firewall interference** – temporarily disable any proxies and open port 80 directly to the server.
+4. **NGINX config missing ACME block** – the first boot may not generate `default.conf` with the challenge location. Add:
+```nginx
+location /.well-known/acme-challenge/ {
+    alias /var/www/certbot/;
+}
+```
+Then reload NGINX with `nginx -t && nginx -s reload`.
+
 
 If any step fails, fix the issue before launching Certbot again.
 

--- a/docs/nginx-certbot.md
+++ b/docs/nginx-certbot.md
@@ -89,6 +89,13 @@ If the test file is reachable, Certbot will obtain the certificate and NGINX wil
 ## Common ACME Challenge Errors
 
 - `404 Not Found` when fetching the challenge file. Confirm that `certbot_webroot` is mounted in both containers and that the path resolves with `docker exec nginx ls -l /var/www/certbot/.well-known/acme-challenge`.
+- Missing `/.well-known/acme-challenge/` block in `default.conf`. Ensure the server config contains:
+```nginx
+location /.well-known/acme-challenge/ {
+    alias /var/www/certbot/;
+}
+```
+Then reload NGINX.
 - DNS pointing to the wrong IP. Run `dig +short yourdomain.com` and ensure it matches the server.
 
 ## Troubleshooting `"server" directive is not allowed here`


### PR DESCRIPTION
## Summary
- note that NGINX may miss the `/.well-known/acme-challenge/` block on first boot
- add troubleshooting step explaining how to insert the block and reload

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a8b15a03c832cbf35d53052ea3da0