### PR TITLE
Fix ACME challenge alias

### DIFF
--- a/docs/certbot-setup.md
+++ b/docs/certbot-setup.md
@@ -18,7 +18,7 @@ NGINX must serve the challenge directory without redirecting it to HTTPS:
 
 ```nginx
 location /.well-known/acme-challenge/ {
-    alias /var/www/certbot/;
+    alias /var/www/certbot/.well-known/acme-challenge/;
 }
 ```
 

--- a/docs/certbot.md
+++ b/docs/certbot.md
@@ -30,7 +30,7 @@ Before requesting a certificate, verify that NGINX serves the challenge director
 
 ```nginx
 location /.well-known/acme-challenge/ {
-    alias /var/www/certbot/;
+    alias /var/www/certbot/.well-known/acme-challenge/;
 }
 ```
 

--- a/docs/first-run.md
+++ b/docs/first-run.md
@@ -103,7 +103,7 @@ These errors typically appear during the first certificate request. Use the chec
 4. **NGINX config missing ACME block** – the container entrypoint now injects this block automatically if missing. If you still don't see it in `/etc/nginx/conf.d/default.conf`, add:
 ```nginx
 location /.well-known/acme-challenge/ {
-    alias /var/www/certbot/;
+    alias /var/www/certbot/.well-known/acme-challenge/;
 }
 ```
 Then reload NGINX with `nginx -t && nginx -s reload`.

--- a/docs/nginx-certbot.md
+++ b/docs/nginx-certbot.md
@@ -38,7 +38,7 @@ Make sure the HTTP server block serves the challenge directory without redirects
 
 ```nginx
 location /.well-known/acme-challenge/ {
-    alias /var/www/certbot/;
+    alias /var/www/certbot/.well-known/acme-challenge/;
 }
 ```
 
@@ -92,7 +92,7 @@ If the test file is reachable, Certbot will obtain the certificate and NGINX wil
 - Missing `/.well-known/acme-challenge/` block in `default.conf`. The container entrypoint now injects this block automatically if it's absent, but verify the server config contains:
 ```nginx
 location /.well-known/acme-challenge/ {
-    alias /var/www/certbot/;
+    alias /var/www/certbot/.well-known/acme-challenge/;
 }
 ```
 Then reload NGINX.

--- a/services/nginx/default.conf.template
+++ b/services/nginx/default.conf.template
@@ -3,7 +3,7 @@ server {
     server_name ${REMOTE_DOMAIN};
 
     location /.well-known/acme-challenge/ {
-        alias /var/www/certbot/;
+        alias /var/www/certbot/.well-known/acme-challenge/;
     }
 
     location / {

--- a/services/nginx/default.http.conf.template
+++ b/services/nginx/default.http.conf.template
@@ -3,7 +3,7 @@ server {
     server_name ${REMOTE_DOMAIN};
 
     location /.well-known/acme-challenge/ {
-        alias /var/www/certbot/;
+        alias /var/www/certbot/.well-known/acme-challenge/;
     }
 
     location / {

--- a/services/nginx/docker-entrypoint.sh
+++ b/services/nginx/docker-entrypoint.sh
@@ -19,7 +19,7 @@ fi
 
 if ! grep -q '/.well-known/acme-challenge/' "$CONF_FILE"; then
     echo "Injecting ACME challenge block into $CONF_FILE"
-    sed -i '/server_name/a\    location /.well-known/acme-challenge/ {\n        alias /var/www/certbot/;\n    }\n' "$CONF_FILE"
+    sed -i '/server_name/a\    location /.well-known/acme-challenge/ {\n        alias /var/www/certbot/.well-known/acme-challenge/;\n    }\n' "$CONF_FILE"
 fi
 
 nginx -t


### PR DESCRIPTION
## Summary
- correct `.well-known` alias path in nginx templates
- inject updated path on container startup
- update documentation to show the right alias

## Testing
- `shellcheck services/nginx/docker-entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a9973701c832cb1c9d6b6bf7c2b03