### PR TITLE
Update troubleshooting docs

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -17,6 +17,21 @@ Below are common issues encountered when deploying the stack.
 - Use `docker exec certbot certbot renew --dry-run` to test renewal.
 - If no certificate is found, rerun `./deploy-script.sh` to request one.
 - Verify DNS points to your server with `dig +short <domain>`.
+- Confirm both `nginx` and `certbot` mount the shared `certbot_webroot` volume.
+- Make sure the ACME challenge location uses a trailing slash in the `alias` path:
+  ```nginx
+  location /.well-known/acme-challenge/ {
+      alias /var/www/certbot/.well-known/acme-challenge/;
+  }
+  ```
+  Without the trailing `/` NGINX may look for files in a duplicated
+  `.well-known` directory and return `404`.
+- Create a test file and fetch it to confirm reachability:
+  ```bash
+  docker run --rm -v certbot_webroot:/var/www/certbot \
+    busybox sh -c 'echo ok > /var/www/certbot/test.txt'
+  curl http://<domain>/.well-known/acme-challenge/test.txt
+  ```
 
 ## Database connection errors
 - Verify the `postgres` container is running and reachable.


### PR DESCRIPTION
## Summary
- expand troubleshooting for Certbot failures

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ab8033334832cb5568ede63a7468e