### PR TITLE
Fix Certbot challenge check path

### DIFF
--- a/deploy-script.sh
+++ b/deploy-script.sh
@@ -73,7 +73,9 @@ if [ ! -d "$CERT_PATH/live/$REMOTE_DOMAIN" ]; then
     docker-compose up -d nginx
 
     echo "🔍 Pre-validating challenge path..."
-    docker run --rm -v "$CERTBOT_WEBROOT_VOLUME":/var/www/certbot busybox sh -c 'echo ok > /var/www/certbot/.well-known-check.txt'
+    docker run --rm -v "$CERTBOT_WEBROOT_VOLUME":/var/www/certbot busybox \
+      sh -c 'mkdir -p /var/www/certbot/.well-known/acme-challenge && \
+      echo ok > /var/www/certbot/.well-known/acme-challenge/.well-known-check.txt'
     for i in $(seq 1 10); do
         if curl -fs "http://$REMOTE_DOMAIN/.well-known/acme-challenge/.well-known-check.txt" >/dev/null; then
             echo "✅ Challenge directory reachable"
@@ -87,7 +89,7 @@ if [ ! -d "$CERT_PATH/live/$REMOTE_DOMAIN" ]; then
         docker-compose logs nginx | tail -n 20
         exit 1
     fi
-    docker run --rm -v "$CERTBOT_WEBROOT_VOLUME":/var/www/certbot busybox rm /var/www/certbot/.well-known-check.txt
+    docker run --rm -v "$CERTBOT_WEBROOT_VOLUME":/var/www/certbot busybox rm /var/www/certbot/.well-known/acme-challenge/.well-known-check.txt
 
     echo "🔐 Requesting initial certificate..."
     docker run --rm \

--- a/docs/first-run.md
+++ b/docs/first-run.md
@@ -95,8 +95,11 @@ These errors typically appear during the first certificate request. Use the chec
    docker exec nginx curl -s localhost/.well-known/acme-challenge/.well-known-check.txt
    docker exec certbot ls /var/www/certbot
    # manually create the check file if needed
-   docker run --rm -v zammad_certbot_webroot:/var/www/certbot busybox sh -c 'echo ok > /var/www/certbot/.well-known-check.txt'
-   docker run --rm -v zammad_certbot_webroot:/var/www/certbot busybox rm /var/www/certbot/.well-known-check.txt
+   docker run --rm -v zammad_certbot_webroot:/var/www/certbot busybox \
+     sh -c 'mkdir -p /var/www/certbot/.well-known/acme-challenge && \
+     echo ok > /var/www/certbot/.well-known/acme-challenge/.well-known-check.txt'
+   docker run --rm -v zammad_certbot_webroot:/var/www/certbot busybox \
+     rm /var/www/certbot/.well-known/acme-challenge/.well-known-check.txt
    ```
    All commands must succeed. If they fail, confirm that both containers share the `certbot_webroot` volume.
 3. **Cloudflare or firewall interference** – temporarily disable any proxies and open port 80 directly to the server.


### PR DESCRIPTION
## Summary
- correct the location of the `.well-known-check.txt` test file in `deploy-script.sh`
- update documentation to reflect the new path

## Testing
- `bash -n deploy-script.sh`
- `shellcheck deploy-script.sh`

------
https://chatgpt.com/codex/tasks/task_e_687aba6539a4832c97140f6d81bdae78