### PR TITLE
Fix Zammad config ownership check

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -37,6 +37,21 @@ Below are common issues encountered when deploying the stack.
 - Verify the `postgres` container is running and reachable.
 - Confirm credentials in `.env` match the database environment variables.
 
+## Zammad permission error
+If the Zammad container repeatedly restarts and `docker logs zammad` shows:
+
+```
+The file /opt/zammad/config/database.yml is not owned by root
+```
+
+the volume files have the wrong ownership. Fix it by resetting the owner:
+
+```bash
+docker-compose run --rm -u root zammad \
+  chown root:root /opt/zammad/config/database.yml
+docker-compose restart zammad
+```
+
 ## Docker DNS failures
 If `docker pull` or `docker-compose up` fail with DNS errors like:
 

--- a/services/zammad/Dockerfile
+++ b/services/zammad/Dockerfile
@@ -6,4 +6,9 @@ EXPOSE 3000 6042
 
 VOLUME ["/opt/zammad"]
 
+# wrapper ensures critical configs are owned by root before starting
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["/docker-entrypoint.sh"]

--- a/services/zammad/entrypoint.sh
+++ b/services/zammad/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# Ensure database.yml ownership so Zammad's startup check passes
+if [ -f /opt/zammad/config/database.yml ]; then
+    chown root:root /opt/zammad/config/database.yml
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary
- ensure `/opt/zammad/config/database.yml` is owned by root before starting
- document how to fix Zammad ownership errors

## Testing
- `shellcheck services/zammad/entrypoint.sh`
- `shellcheck deploy-script.sh`

------
https://chatgpt.com/codex/tasks/task_e_687ac1d39080832c9c337cc8f2f7da69