### PR TITLE
Fix zammad Dockerfile build path

### DIFF
--- a/services/zammad/Dockerfile
+++ b/services/zammad/Dockerfile
@@ -7,7 +7,7 @@ EXPOSE 3000 6042
 VOLUME ["/opt/zammad"]
 
 # wrapper ensures critical configs are owned by root before starting
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY zammad/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- adjust COPY path in `services/zammad/Dockerfile` so build context finds `entrypoint.sh`

## Testing
- `docker buildx build --load -t test/zammad -f services/zammad/Dockerfile services` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ac394b8cc832c882edbd9b5ac4b80