### PR TITLE
Fix entrypoint permission issue

### DIFF
--- a/docs/zammad.md
+++ b/docs/zammad.md
@@ -9,6 +9,20 @@
 
 Zammad provides the ticketing UI and API. The container is built from `services/zammad/Dockerfile` and depends on the `postgres` and `elasticsearch` services.
 
+The base image runs as the `zammad` user. When the custom `entrypoint.sh` script
+is added, the Dockerfile temporarily switches to `root` to mark the script as
+executable and then switches back:
+
+```dockerfile
+COPY zammad/entrypoint.sh /usr/local/bin/entrypoint.sh
+USER root
+RUN chmod +x /usr/local/bin/entrypoint.sh
+USER zammad
+```
+
+This ensures the script has the right permissions during build without changing
+the default runtime user.
+
 ## Data Volume
 
 - **`zammad_data`** mounted at `/opt/zammad`

--- a/services/zammad/Dockerfile
+++ b/services/zammad/Dockerfile
@@ -8,7 +8,12 @@ VOLUME ["/opt/zammad"]
 
 # wrapper ensures critical configs are owned by root before starting
 COPY zammad/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+# Ensure the script is executable. The base image defaults to a non-root user,
+# so temporarily switch to root for the permission change.
+USER root
 RUN chmod +x /usr/local/bin/entrypoint.sh
+USER zammad
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["/docker-entrypoint.sh"]


### PR DESCRIPTION
## Summary
- ensure Zammad entrypoint script is chmod'd as root
- document the build step that switches to root

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ac7661c20832c814004cffb3a6cc3