### PR TITLE
Fix Postgres connection instructions

### DIFF
--- a/docs/first-run-checks.md
+++ b/docs/first-run-checks.md
@@ -34,7 +34,8 @@ Example checks:
 
 ```bash
 docker logs zammad
-docker exec -it postgres psql -U postgres
+# Connect to the database (default user is "zammad")
+docker exec -it postgres psql -U ${POSTGRES_USER:-zammad}
 ```
 
 ## 🛠️ Common Issues + Fixes

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -36,6 +36,8 @@ Below are common issues encountered when deploying the stack.
 ## Database connection errors
 - Verify the `postgres` container is running and reachable.
 - Confirm credentials in `.env` match the database environment variables.
+- If `psql` reports `role "postgres" does not exist`, connect using the username
+  defined by `POSTGRES_USER` (default `zammad`).
 
 ## Zammad permission error
 If the Zammad container repeatedly restarts and `docker logs zammad` shows:


### PR DESCRIPTION
## Summary
- correct the `psql` command in the first run guide to use the configured user
- document the `role "postgres" does not exist` error in the troubleshooting guide

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687aca8f60e0832ca7bcf6a5b1861c2c