### PR TITLE
Fix nginx homepage after cert issue

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -33,6 +33,20 @@ Below are common issues encountered when deploying the stack.
   curl http://<domain>/.well-known/acme-challenge/test.txt
   ```
 
+## Default NGINX page instead of homepage
+If navigating to your domain shows the "Welcome to nginx!" page, the base image's
+`default.conf` may have overridden the project configuration. Rebuild the `nginx`
+service to ensure `/etc/nginx/conf.d/default.conf` is generated from
+`default.conf.template`:
+
+```bash
+docker-compose build nginx
+docker-compose up -d nginx
+```
+
+After rebuilding, visiting `http://<domain>` should display the custom
+`index.html` included in `services/nginx/html/`.
+
 ## Database connection errors
 - Verify the `postgres` container is running and reachable.
 - Confirm credentials in `.env` match the database environment variables.

--- a/services/nginx/Dockerfile
+++ b/services/nginx/Dockerfile
@@ -5,7 +5,8 @@ FROM nginx:alpine
 COPY nginx /tmp/nginx
 COPY common/ensure-config.sh /usr/local/bin/ensure-config.sh
 
-RUN chmod +x /usr/local/bin/ensure-config.sh /tmp/nginx/docker-entrypoint.sh \
+RUN rm -f /etc/nginx/conf.d/default.conf \
+    && chmod +x /usr/local/bin/ensure-config.sh /tmp/nginx/docker-entrypoint.sh \
     && if [ -f /tmp/nginx/nginx.conf ]; then \
          echo "✅ Using provided nginx.conf"; \
          cp /tmp/nginx/nginx.conf /etc/nginx/nginx.conf; \
@@ -15,7 +16,7 @@ RUN chmod +x /usr/local/bin/ensure-config.sh /tmp/nginx/docker-entrypoint.sh \
        fi \
     && cp /tmp/nginx/default.conf.template /etc/nginx/conf.d/default.conf.template \
     && cp /tmp/nginx/default.http.conf.template /etc/nginx/conf.d/default.http.conf.template \
-    && cp -r /tmp/nginx/html /usr/share/nginx/html \
+    && cp -r /tmp/nginx/html/* /usr/share/nginx/html/ \
     && mv /tmp/nginx/docker-entrypoint.sh /docker-entrypoint.sh \
     && chmod +x /docker-entrypoint.sh \
     && rm -rf /tmp/nginx


### PR DESCRIPTION
## Summary
- remove default NGINX config so our config is used
- ensure homepage files copy correctly
- add note on rebuilding nginx when welcome page appears

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b43e70cf8832c9cf2857b9ba4ed4a