### PR TITLE
Fix nginx upstream resolution

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -47,6 +47,32 @@ docker-compose up -d nginx
 After rebuilding, visiting `http://<domain>` should display the custom
 `index.html` included in `services/nginx/html/`.
 
+## NGINX fails with `"host not found in upstream"`
+If `docker logs nginx` shows an error like:
+
+```
+host not found in upstream "zammad" in /etc/nginx/conf.d/default.conf:27
+```
+
+the proxy container cannot resolve the `zammad` hostname. Ensure the
+Docker resolver is explicitly specified in the NGINX config. The
+provided `default.conf.template` includes:
+
+```nginx
+location /zammad/ {
+    resolver 127.0.0.11;
+    proxy_pass http://zammad:3000/;
+    ...
+}
+```
+
+Rebuild the `nginx` image and restart the service:
+
+```bash
+docker-compose build nginx
+docker-compose up -d nginx
+```
+
 ## Database connection errors
 - Verify the `postgres` container is running and reachable.
 - Confirm credentials in `.env` match the database environment variables.

--- a/services/nginx/default.conf.template
+++ b/services/nginx/default.conf.template
@@ -24,6 +24,7 @@ server {
     }
 
     location /zammad/ {
+        resolver 127.0.0.11;
         proxy_pass http://zammad:3000/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
- specify Docker resolver inside NGINX template
- document how to fix the `host not found in upstream` error in troubleshooting guide

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b46f17d78832c835943a0af2b4b9a