### PR TITLE
Fix nginx upstream resolution

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -54,14 +54,15 @@ If `docker logs nginx` shows an error like:
 host not found in upstream "zammad" in /etc/nginx/conf.d/default.conf:27
 ```
 
-the proxy container cannot resolve the `zammad` hostname. Ensure the
-Docker resolver is explicitly specified in the NGINX config. The
-provided `default.conf.template` includes:
+the proxy container cannot resolve the `zammad` hostname during the
+initial configuration test. The template now defers DNS resolution by
+using a variable in `proxy_pass`:
 
 ```nginx
 location /zammad/ {
     resolver 127.0.0.11;
-    proxy_pass http://zammad:3000/;
+    set $zammad_upstream "zammad:3000";
+    proxy_pass http://$zammad_upstream/;
     ...
 }
 ```

--- a/services/nginx/default.conf.template
+++ b/services/nginx/default.conf.template
@@ -25,7 +25,8 @@ server {
 
     location /zammad/ {
         resolver 127.0.0.11;
-        proxy_pass http://zammad:3000/;
+        set $zammad_upstream "zammad:3000";
+        proxy_pass http://$zammad_upstream/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary
- avoid nginx DNS error during startup by deferring hostname resolution
- document the updated approach in troubleshooting guide

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687b4a24bc4c832c9d516665cdb22af4