### PR TITLE
Fix README page in wiki

### DIFF
--- a/docs/README/index.md
+++ b/docs/README/index.md
@@ -23,7 +23,7 @@ This repository represents my first step into the world of open-source collabora
    - A record must point to your server's IP.
 3. **Jenkins CI/CD**
    - Handles deployment and injects secrets such as SSH keys, domain details and DockerHub credentials.
-   - Prepare the Jenkins host for SSH as described in [Jenkins SSH Setup on Host Machine](first-run.md#-jenkins-ssh-setup-on-host-machine).
+   - Prepare the Jenkins host for SSH as described in [Jenkins SSH Setup on Host Machine](../first-run.md#-jenkins-ssh-setup-on-host-machine).
 4. **Azure Tenant with Admin Access**
    - Required for Microsoft 365 shared mailboxes, Entra ID authentication and Teams/SharePoint integrations.
 
@@ -69,7 +69,7 @@ In the longer term, I'm enthusiastic about exploring integrations with **AI agen
    ```bash
    docker-compose up -d
    ```
-4. Visit `http://localhost` to see the landing page. For production deployment follow the [Deployment guide](deployment.md).
+4. Visit `http://localhost` to see the landing page. For production deployment follow the [Deployment guide](../deployment.md).
 
 ## 📚 Learning Together
 
@@ -88,22 +88,22 @@ Contributions are welcome! Fork the repository, create a feature branch and open
 
 ## 📖 Documentation
 
-All additional guides are stored in the [docs/](./) directory:
+All additional guides are stored in the [docs/](../) directory:
 
-- **[deployment.md](deployment.md)** – step-by-step Docker setup and environments.
-- **[ci-cd-pipeline.md](ci-cd-pipeline.md)** – Jenkins and automation logic.
-- **[authentication.md](authentication.md)** – LDAP, Entra ID, Microsoft login setup.
-- **[email-integration.md](email-integration.md)** – Outlook, shared mailbox config.
-- **[branding.md](branding.md)** – Customization and UI theming.
-- **[certbot.md](certbot.md)** – HTTPS setup with Certbot.
-- **[certbot-setup.md](certbot-setup.md)** – How ACME HTTP-01 works and troubleshooting tips.
-- **[certbot-debug.md](certbot-debug.md)** – Run a standalone Certbot container for manual testing.
-- **[nginx-certbot.md](nginx-certbot.md)** – NGINX proxy configuration and Cloudflare notes.
-- **[secrets.md](secrets.md)** – Overview of Jenkins credential IDs.
-- **[first-run.md](first-run.md)** – Troubleshoot common first-run errors, including [Certbot failures](first-run.md#-common-certbot-failures-and-how-to-fix-them).
-- **[troubleshooting.md](troubleshooting.md)** – Accessing logs, common errors.
-- **[zammad.md](zammad.md)** – Zammad service and admin setup.
-- **[wiki.md](wiki.md)** – Container serving the documentation at `/wiki`.
+- **[deployment.md](../deployment.md)** – step-by-step Docker setup and environments.
+- **[ci-cd-pipeline.md](../ci-cd-pipeline.md)** – Jenkins and automation logic.
+- **[authentication.md](../authentication.md)** – LDAP, Entra ID, Microsoft login setup.
+- **[email-integration.md](../email-integration.md)** – Outlook, shared mailbox config.
+- **[branding.md](../branding.md)** – Customization and UI theming.
+- **[certbot.md](../certbot.md)** – HTTPS setup with Certbot.
+- **[certbot-setup.md](../certbot-setup.md)** – How ACME HTTP-01 works and troubleshooting tips.
+- **[certbot-debug.md](../certbot-debug.md)** – Run a standalone Certbot container for manual testing.
+- **[nginx-certbot.md](../nginx-certbot.md)** – NGINX proxy configuration and Cloudflare notes.
+- **[secrets.md](../secrets.md)** – Overview of Jenkins credential IDs.
+- **[first-run.md](../first-run.md)** – Troubleshoot common first-run errors, including [Certbot failures](../first-run.md#-common-certbot-failures-and-how-to-fix-them).
+- **[troubleshooting.md](../troubleshooting.md)** – Accessing logs, common errors.
+- **[zammad.md](../zammad.md)** – Zammad service and admin setup.
+- **[wiki.md](../wiki.md)** – Container serving the documentation at `/wiki`.
 
 These documents will grow alongside the project as more features (like Microsoft 365 integration or n8n workflows) are added.
 

--- a/docs/agent_prompt.md
+++ b/docs/agent_prompt.md
@@ -1,6 +1,6 @@
-[← Back to Main README](../README.md)
+[← Back to Main README](README/index.md)
 
-> **Prerequisite:** Familiarize yourself with the [Requirements & Prerequisites](../README.md#-requirements--prerequisites) before contributing.
+> **Prerequisite:** Familiarize yourself with the [Requirements & Prerequisites](README/index.md#-requirements--prerequisites) before contributing.
 
 You are contributing to an open-source project designed to create a secure, modular, and easy-to-deploy ticketing and automation platform based on Zammad and Docker. This project is being actively built to serve small to mid-sized organizations and educational purposes.
 
@@ -162,5 +162,5 @@ Work in the following order:
 Continue with the next step by checking the `/docs` directory and creating/expanding a service if it’s not complete.
 
 ---
-🔗 Back to [Main README](../README.md)  
+🔗 Back to [Main README](README/index.md)  
 📚 See also: [Deployment](deployment.md) | [CI/CD](ci-cd-pipeline.md)

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,6 +1,6 @@
-[← Back to Main README](../README.md)
+[← Back to Main README](README/index.md)
 
-> **Prerequisite:** Ensure the [Requirements & Prerequisites](../README.md#-requirements--prerequisites) are met, particularly Azure tenant admin access.
+> **Prerequisite:** Ensure the [Requirements & Prerequisites](README/index.md#-requirements--prerequisites) are met, particularly Azure tenant admin access.
 
 # Authentication and SSO
 
@@ -12,5 +12,5 @@ Zammad can integrate with Microsoft 365 / Entra ID for single sign-on.
 When implemented, configure the necessary OAuth application in Microsoft 365 and store the credentials in Jenkins. Reference these credential IDs from the pipeline to pass them into the container.
 
 ---
-🔗 Back to [Main README](../README.md)  
+🔗 Back to [Main README](README/index.md)  
 📚 See also: [Deployment](deployment.md) | [CI/CD](ci-cd-pipeline.md) | [Secrets](secrets.md)

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -1,6 +1,6 @@
-[← Back to Main README](../README.md)
+[← Back to Main README](README/index.md)
 
-> **Prerequisite:** Review the [Requirements & Prerequisites](../README.md#-requirements--prerequisites) before customizing branding.
+> **Prerequisite:** Review the [Requirements & Prerequisites](README/index.md#-requirements--prerequisites) before customizing branding.
 
 # Branding
 
@@ -15,5 +15,5 @@ Zammad supports theming and custom branding through its admin interface. Upload 
 The landing page served by NGINX is located at `services/nginx/html/index.html`. Edit this file and rebuild the `nginx` service to apply changes.
 
 ---
-🔗 Back to [Main README](../README.md)  
+🔗 Back to [Main README](README/index.md)  
 📚 See also: [Deployment](deployment.md) | [Homepage](homepage.md)

--- a/docs/certbot-debug.md
+++ b/docs/certbot-debug.md
@@ -1,4 +1,4 @@
-[← Back to Main README](../README.md)
+[← Back to Main README](README/index.md)
 
 # Certbot Debugging Guide
 
@@ -23,5 +23,5 @@ curl http://yourdomain.com/.well-known/acme-challenge/<token>
 Press `Ctrl+C` to stop the script or let Certbot finish. No real certificate is issued because the `--dry-run` option uses the Let's Encrypt staging environment.
 
 ---
-🔗 Back to [Main README](../README.md)
+🔗 Back to [Main README](README/index.md)
 📚 See also: [certbot.md](certbot.md) | [certbot-setup.md](certbot-setup.md)

--- a/docs/certbot-setup.md
+++ b/docs/certbot-setup.md
@@ -1,4 +1,4 @@
-[← Back to Main README](../README.md)
+[← Back to Main README](README/index.md)
 
 > **Prerequisite:** Ensure your domain's DNS A record points to the VPS IP and ports 80/443 are reachable.
 
@@ -49,5 +49,5 @@ curl http://<domain>/.well-known/acme-challenge/test.txt
 A successful response confirms that DNS and NGINX are correctly configured.
 
 ---
-🔗 Back to [Main README](../README.md)
+🔗 Back to [Main README](README/index.md)
 📚 See also: [certbot.md](certbot.md) | [First Run](first-run.md)

--- a/docs/certbot.md
+++ b/docs/certbot.md
@@ -1,6 +1,6 @@
-[← Back to Main README](../README.md)
+[← Back to Main README](README/index.md)
 
-> **Prerequisite:** Review the [Requirements & Prerequisites](../README.md#-requirements--prerequisites). No extra dependencies beyond a configured domain.
+> **Prerequisite:** Review the [Requirements & Prerequisites](README/index.md#-requirements--prerequisites). No extra dependencies beyond a configured domain.
 
 # NGINX and Certbot Integration
 
@@ -190,5 +190,5 @@ The full NGINX configuration is stored in [`services/nginx/default.conf.template
 - [`services/nginx/nginx.conf`](../services/nginx/nginx.conf)
 
 ---
-🔗 Back to [Main README](../README.md)
+🔗 Back to [Main README](README/index.md)
 📚 See also: [certbot-debug](certbot-debug.md) | [Deployment](deployment.md) | [CI/CD](ci-cd-pipeline.md) | [Secrets](secrets.md)

--- a/docs/ci-cd-pipeline.md
+++ b/docs/ci-cd-pipeline.md
@@ -1,6 +1,6 @@
-[← Back to Main README](../README.md)
+[← Back to Main README](README/index.md)
 
-> **Prerequisite:** Ensure the [Requirements & Prerequisites](../README.md#-requirements--prerequisites) are satisfied. Jenkins must already be installed.
+> **Prerequisite:** Ensure the [Requirements & Prerequisites](README/index.md#-requirements--prerequisites) are satisfied. Jenkins must already be installed.
 
 # Jenkins CI/CD Pipeline
 
@@ -84,5 +84,5 @@ A successful run looks similar to:
 - The build stage only runs if a `services/` directory with Dockerfiles exists. If no custom services are needed you will only see pull and deploy steps.
 
 ---
-🔗 Back to [Main README](../README.md)  
+🔗 Back to [Main README](README/index.md)  
 📚 See also: [Deployment](deployment.md) | [Certbot](certbot.md) | [Secrets](secrets.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,6 +1,6 @@
-[← Back to Main README](../README.md)
+[← Back to Main README](README/index.md)
 
-> **Prerequisite:** Review the [Requirements & Prerequisites](../README.md#-requirements--prerequisites). No additional setup is required for this guide.
+> **Prerequisite:** Review the [Requirements & Prerequisites](README/index.md#-requirements--prerequisites). No additional setup is required for this guide.
 
 # Deployment Guide – Zammad Docker Stack
 
@@ -68,5 +68,5 @@ These volumes are defined in `docker-compose.yaml` and ensure data is retained a
 5. After the stack is online, follow the [First Run Checks](first-run-checks.md) guide to verify services and troubleshoot any issues.
 
 ---
-🔗 Back to [Main README](../README.md)  
+🔗 Back to [Main README](README/index.md)  
 📚 See also: [CI/CD](ci-cd-pipeline.md) | [Certbot](certbot.md) | [Secrets](secrets.md) | [Zammad](zammad.md)

--- a/docs/email-integration.md
+++ b/docs/email-integration.md
@@ -1,6 +1,6 @@
-[← Back to Main README](../README.md)
+[← Back to Main README](README/index.md)
 
-> **Prerequisite:** Review the [Requirements & Prerequisites](../README.md#-requirements--prerequisites). Azure tenant admin access is required for mailbox configuration.
+> **Prerequisite:** Review the [Requirements & Prerequisites](README/index.md#-requirements--prerequisites). Azure tenant admin access is required for mailbox configuration.
 
 # Email Integration
 
@@ -21,5 +21,5 @@ Microsoft 365 OAuth2 credentials and SMTP settings are provided via the followin
 Configure these secrets in Jenkins and reference them in the pipeline so the Zammad container can authenticate with Microsoft 365.
 
 ---
-🔗 Back to [Main README](../README.md)  
+🔗 Back to [Main README](README/index.md)  
 📚 See also: [Authentication](authentication.md) | [Deployment](deployment.md) | [Secrets](secrets.md)

--- a/docs/first-run-checks.md
+++ b/docs/first-run-checks.md
@@ -1,6 +1,6 @@
-[← Back to Main README](../README.md)
+[← Back to Main README](README/index.md)
 
-> **Prerequisite:** Ensure your environment meets the [Requirements & Prerequisites](../README.md#-requirements--prerequisites).
+> **Prerequisite:** Ensure your environment meets the [Requirements & Prerequisites](README/index.md#-requirements--prerequisites).
 
 # First Run Checks & Troubleshooting Guide
 
@@ -89,5 +89,5 @@ zammad run rails c
 ```
 
 ---
-🔗 Back to [Main README](../README.md)  
+🔗 Back to [Main README](README/index.md)  
 📚 See also: [Troubleshooting](troubleshooting.md) | [Deployment](deployment.md)

--- a/docs/first-run.md
+++ b/docs/first-run.md
@@ -1,6 +1,6 @@
-[← Back to Main README](../README.md)
+[← Back to Main README](README/index.md)
 
-> **Prerequisite:** Ensure the [Requirements & Prerequisites](../README.md#-requirements--prerequisites) are met.
+> **Prerequisite:** Ensure the [Requirements & Prerequisites](README/index.md#-requirements--prerequisites) are met.
 
 # First Run Guide
 
@@ -115,5 +115,5 @@ Then reload NGINX with `nginx -t && nginx -s reload`.
 If any step fails, fix the issue before launching Certbot again.
 
 ---
-🔗 Back to [Main README](../README.md)
+🔗 Back to [Main README](README/index.md)
 📚 See also: [First Run Checks](first-run-checks.md) | [Deployment](deployment.md) | [Troubleshooting](troubleshooting.md)

--- a/docs/homepage.md
+++ b/docs/homepage.md
@@ -1,6 +1,6 @@
-[← Back to Main README](../README.md)
+[← Back to Main README](README/index.md)
 
-> **Prerequisite:** Ensure the [Requirements & Prerequisites](../README.md#-requirements--prerequisites) are in place.
+> **Prerequisite:** Ensure the [Requirements & Prerequisites](README/index.md#-requirements--prerequisites) are in place.
 
 # Homepage
 
@@ -14,5 +14,5 @@ Links are provided to:
 Edit `index.html` and rebuild the `nginx` service to change the content.
 
 ---
-🔗 Back to [Main README](../README.md)  
+🔗 Back to [Main README](README/index.md)  
 📚 See also: [Branding](branding.md) | [Deployment](deployment.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-[← Back to Main README](README.md)
+[← Back to Main README](README/index.md)
 
 # Project Wiki
 
@@ -6,4 +6,4 @@ This site provides a web-based view of the documentation stored in the `docs/` d
 Use the navigation sidebar to browse through the available guides.
 
 ---
-🔗 Back to [Main README](README.md)
+🔗 Back to [Main README](README/index.md)

--- a/docs/nginx-certbot.md
+++ b/docs/nginx-certbot.md
@@ -1,4 +1,4 @@
-[← Back to Main README](../README.md)
+[← Back to Main README](README/index.md)
 
 # NGINX and Certbot Configuration
 
@@ -115,6 +115,6 @@ nginx -t
 This command should report `syntax is ok` and `test is successful`.
 
 ---
-🔗 Back to [Main README](../README.md)
+🔗 Back to [Main README](README/index.md)
 📚 See also: [certbot.md](certbot.md) | [deployment](deployment.md)
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,6 +1,6 @@
-[← Back to Main README](../README.md)
+[← Back to Main README](README/index.md)
 
-> **Prerequisite:** Review the [Requirements & Prerequisites](../README.md#-requirements--prerequisites). Jenkins manages these secrets externally.
+> **Prerequisite:** Review the [Requirements & Prerequisites](README/index.md#-requirements--prerequisites). Jenkins manages these secrets externally.
 
 # Jenkins Secrets Index
 
@@ -26,5 +26,5 @@ The following credential IDs are referenced by the deployment pipeline. Values a
 | `zammad-admin-password`                 | Initial admin password |
 
 ---
-🔗 Back to [Main README](../README.md)  
+🔗 Back to [Main README](README/index.md)  
 📚 See also: [CI/CD](ci-cd-pipeline.md) | [Deployment](deployment.md)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
-[← Back to Main README](../README.md)
+[← Back to Main README](README/index.md)
 
-> **Prerequisite:** Confirm the [Requirements & Prerequisites](../README.md#-requirements--prerequisites) are met before diagnosing issues.
+> **Prerequisite:** Confirm the [Requirements & Prerequisites](README/index.md#-requirements--prerequisites) are met before diagnosing issues.
 
 # Troubleshooting
 
@@ -120,5 +120,5 @@ docker run --rm busybox nslookup google.com
 Both commands should succeed without DNS errors.
 
 ---
-🔗 Back to [Main README](../README.md)  
+🔗 Back to [Main README](README/index.md)  
 📚 See also: [First Run Checks](first-run-checks.md) | [Deployment](deployment.md)

--- a/docs/wiki.md
+++ b/docs/wiki.md
@@ -1,6 +1,6 @@
-[← Back to Main README](../README.md)
+[← Back to Main README](README/index.md)
 
-> **Prerequisite:** Ensure the [Requirements & Prerequisites](../README.md#-requirements--prerequisites) are met.
+> **Prerequisite:** Ensure the [Requirements & Prerequisites](README/index.md#-requirements--prerequisites) are met.
 
 # Wiki Service
 
@@ -26,5 +26,5 @@ docker logs wiki
 ```
 
 ---
-🔗 Back to [Main README](../README.md)
+🔗 Back to [Main README](README/index.md)
 📚 See also: [Homepage](homepage.md) | [First Run Checks](first-run-checks.md)

--- a/docs/zammad.md
+++ b/docs/zammad.md
@@ -1,6 +1,6 @@
-[← Back to Main README](../README.md)
+[← Back to Main README](README/index.md)
 
-> **Prerequisite:** Ensure the [Requirements & Prerequisites](../README.md#-requirements--prerequisites) are fulfilled before deploying Zammad.
+> **Prerequisite:** Ensure the [Requirements & Prerequisites](README/index.md#-requirements--prerequisites) are fulfilled before deploying Zammad.
 
 > **⚠️ Sensitive Keys**
 > All required keys and secrets for this integration are injected securely via Jenkins and are not stored in this repository.
@@ -70,5 +70,5 @@ If the service fails to start:
 - Ensure permissions on the `zammad_data` volume allow write access.
 
 ---
-🔗 Back to [Main README](../README.md)  
+🔗 Back to [Main README](README/index.md)  
 📚 See also: [Deployment](deployment.md) | [First Run Checks](first-run-checks.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Zammad Ticketing Wiki
 nav:
   - Home: index.md
-  - Main README: README.md
+  - Main README: README/index.md
   - Deployment: deployment.md
   - CI/CD Pipeline: ci-cd-pipeline.md
   - Authentication: authentication.md

--- a/services/wiki/Dockerfile
+++ b/services/wiki/Dockerfile
@@ -7,4 +7,5 @@ RUN pip install --no-cache-dir mkdocs mkdocs-material
 RUN mkdocs build --site-dir /site
 
 FROM nginx:alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /site /usr/share/nginx/html

--- a/services/wiki/nginx.conf
+++ b/services/wiki/nginx.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Redirect Markdown file requests to directory URLs
+    rewrite ^/(.*)\.md$ /$1/ permanent;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}


### PR DESCRIPTION
## Summary
- ensure README is built at /wiki/README/
- update internal docs links
- add nginx rewrite for markdown files

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_687b5e640fb0832c8ebae81bca296e6e