### PR TITLE
Fix wiki README path redirect

### DIFF
--- a/services/wiki/nginx.conf
+++ b/services/wiki/nginx.conf
@@ -3,8 +3,10 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Redirect Markdown file requests to directory URLs
-    rewrite ^/(.*)\.md$ /$1/ permanent;
+    # Redirect Markdown file requests to directory URLs while preserving
+    # the /wiki prefix so links like /wiki/README.md correctly redirect
+    # to /wiki/README/ instead of /README/
+    rewrite ^/(.*)\.md$ /wiki/$1/ permanent;
 
     location / {
         try_files $uri $uri/ =404;


### PR DESCRIPTION
## Summary
- preserve `/wiki` prefix when rewriting Markdown URLs

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_687baa5fc0f8832ca21b7d51c4e39949