### PR TITLE
fix: correct service build paths

### DIFF
--- a/services/recipes-api/Dockerfile
+++ b/services/recipes-api/Dockerfile
@@ -10,7 +10,8 @@ COPY recipes-api/requirements.txt /tmp/requirements.txt
 
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
-COPY services/recipes-api/app /app/app
+# Build context is the services directory, so paths are relative to it
+COPY recipes-api/app /app/app
 
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/recipes-frontend/Dockerfile
+++ b/services/recipes-frontend/Dockerfile
@@ -1,7 +1,7 @@
 # Build stage
 FROM node:20-alpine AS build
 WORKDIR /app
-COPY recipes-frontend/package.json services/recipes-frontend/package-lock.json* ./
+COPY recipes-frontend/package.json recipes-frontend/package-lock.json* ./
 RUN npm install --no-audit --no-fund
 COPY recipes-frontend/ ./
 RUN npm run build


### PR DESCRIPTION
## Summary
- fix recipes-api Dockerfile path so app directory copies correctly
- fix recipes-frontend Dockerfile path for package-lock copy

## Testing
- `docker build -t test-recipes-api -f services/recipes-api/Dockerfile services` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `docker build -t test-recipes-frontend -f services/recipes-frontend/Dockerfile services` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_689b44b09598832c80a32d4ec75571bf